### PR TITLE
Issue #200 / Fix incorrect ModifiedAt timestamps for S3

### DIFF
--- a/server/model/backend/s3.go
+++ b/server/model/backend/s3.go
@@ -130,7 +130,7 @@ func (s S3Backend) Ls(path string) ([]os.FileInfo, error) {
 			files = append(files, &File{
 				FName:   *bucket.Name,
 				FType:   "directory",
-				FTime:   bucket.CreationDate.UnixNano() / 1000,
+				FTime:   bucket.CreationDate.Unix(),
 				CanMove: NewBool(false),
 			})
 		}
@@ -151,7 +151,7 @@ func (s S3Backend) Ls(path string) ([]os.FileInfo, error) {
 		files = append(files, &File{
 			FName: filepath.Base(*object.Key),
 			FType: "file",
-			FTime: object.LastModified.UnixNano() / 1000,
+			FTime: object.LastModified.Unix(),
 			FSize: *object.Size,
 		})
 	}


### PR DESCRIPTION
Fixes #200 

The problem addressed here is that the FileInfo struct's FTime field is
set in S3 backend. This was being passed as milliseconds epoch. That
value was being passed into `time.Unix(x, 0)` which accepts arguments as
either/both (seconds, nanoseconds).

By passing milliseconds to this function expecting seconds, we have
wildly incorrect modified at timestamps.

I tested this against the same bucket that was problematic before and
it's now showing correctly :).

<img width="624" alt="Image 2019-09-28 at 5 22 52 PM" src="https://user-images.githubusercontent.com/1026584/65822581-c5f67f00-e214-11e9-8515-5c9ecdcb0e3a.png">
