### PR TITLE
fix (s3): fix remove a single object

### DIFF
--- a/server/model/backend/s3.go
+++ b/server/model/backend/s3.go
@@ -226,6 +226,14 @@ func (s S3Backend) Rm(path string) error {
 		return NewError("Doesn't exist", 404)
 	}
 
+	if !strings.HasSuffix(p.path, "/") {
+		_, err := client.DeleteObject(&s3.DeleteObjectInput{
+			Bucket: aws.String(p.bucket),
+			Key:    &p.path,
+		})
+		return err
+	}
+
 	objs, err := client.ListObjects(&s3.ListObjectsInput{
 		Bucket:    aws.String(p.bucket),
 		Prefix:    aws.String(p.path),


### PR DESCRIPTION
Thank you for developing filestash. I really appreciate it!

While working with s3 backend I found bug:

In S3 backend, objects, as well as buckets are removed basing on objecs list received from client. As the objects are fetched by Prefix, the request for removing object 'foo' will remove all 'foo*' objects in this bucket.

For instance, having bucket with objects like so:

```
    awesomebucket/
    ├── foo
    ├── foobar
    └── thing
```

`Rm("awesomebucket/foo")` will have effect:

```
    awesomebucket/
    └── thing
```

This change fixes this bug by recognizing if single object has to be
removed or the entire bucket. For single object, we don't need to walk
through directories and can request to remove directly.


I'm using S3 backend exposed via RADOS Gateway.

Cheers