### PR TITLE
fix (s3): fix remove a single object

### DIFF
--- a/server/model/backend/s3.go
+++ b/server/model/backend/s3.go
@@ -226,6 +226,14 @@ func (s S3Backend) Rm(path string) error {
 		return NewError("Doesn't exist", 404)
 	}
 
+	if !strings.HasSuffix(p.path, "/") {
+		_, err := client.DeleteObject(&s3.DeleteObjectInput{
+			Bucket: aws.String(p.bucket),
+			Key:    &p.path,
+		})
+		return err
+	}
+
 	objs, err := client.ListObjects(&s3.ListObjectsInput{
 		Bucket:    aws.String(p.bucket),
 		Prefix:    aws.String(p.path),


### PR DESCRIPTION
This PR apply fix for removing single object described in #225

The previous fix broked the build due to badly used condition for recognizing bucket/object resources.
This resulted in empty string passed as a key, and the validation error returned from aws sdk.

Using path string instead of s3 path solves the issue.

It would be great to re-execute build - this kind of functionality is hard to test manually and perfect to cover by automated tests.