### PR TITLE
fix (s3): mv does not work for nested objects

### DIFF
--- a/server/model/backend/s3.go
+++ b/server/model/backend/s3.go
@@ -275,7 +275,7 @@ func (s S3Backend) Mv(from string, to string) error {
 	t := s.path(to)
 	client := s3.New(s.createSession(f.bucket))
 
-	if f.path == "" {
+	if f.path == "" || strings.HasSuffix(from, "/") {
 		return NewError("Can't move this", 403)
 	}
 


### PR DESCRIPTION
The mv operation executes `CopyObject` API on the root object, meanwhile `CopyObject` doesn't copy the nested objects.

As a result, the user loses all nested objects and after the move operation gets an empty bucket that requested to move.

This change disallows possibility of moving nested objects.

---
I spend some time implementing recursive moving but it failed in some cases so it needs more time and automated tests coverage to avoid unexpected data lost.

Furthermore, relying on the `ListObjects()` api call to fetch objects list may fail on huge objects -
by default, there is a limit for received objects (by default 10k, configurable by `MaxKeys` field in `ListObjectsInput` struct).
To avoid a scenario where only part of data was copied and the rest of them was removed, there should be extra logic checking if copy operation succeeds.
