### PR TITLE
fix (config): synchronise cache writes

### DIFF
--- a/server/common/config.go
+++ b/server/common/config.go
@@ -414,6 +414,7 @@ func (this *Configuration) Get(key string) *Configuration {
 	}
 
 	// increase speed (x4 with our bench) by using a cache
+	this.mu.Lock()
 	tmp := this.cache.Get(key)
 	if tmp == nil {
 		this.currentElement = traverse(&this.form, strings.Split(key, "."))
@@ -421,6 +422,7 @@ func (this *Configuration) Get(key string) *Configuration {
 	} else {
 		this.currentElement = tmp.(*FormElement)
 	}
+	this.mu.Unlock()
 	return this
 }
 


### PR DESCRIPTION
The Config singleton uses single value for non read only access in the `Config.Get()` method, which is not synchronized between different threads, making this method non thread safe.

It may lead to race-condition issues and unexpected config changes in runtime.

This PR is solving these issues.