### PR TITLE
Remove loading objects in case of batch operation fails

### DIFF
--- a/client/model/files.js
+++ b/client/model/files.js
@@ -284,6 +284,7 @@ class FileSystem{
                     })
                     .catch((err) => {
                         this._replace(destination_path, null, 'error')
+                            .then(() => this._replace(destination_path, null, 'loading'))
                             .then(() => this._refresh(destination_path));
                         return Promise.reject(err);
                     });


### PR DESCRIPTION
In case of batch operation, when upload fails there still appear loading object in destination folder. Then only solution is to flush a cache to remove this object. This PR introduces removal of loading objects in given case.