### PR TITLE
Add option to run the app under a non-root URL.

### DIFF
--- a/client/components/breadcrumb.js
+++ b/client/components/breadcrumb.js
@@ -87,7 +87,7 @@ const Logout = (props) => {
     if(isRunningFromAnIframe) return null;
     return (
         <div className="li component_logout">
-          <Link to="/logout">
+          <Link to={window.URL_PREFIX + "/logout"}>
             <Icon name="power"/>
           </Link>
         </div>
@@ -136,7 +136,7 @@ export class PathElementWrapper extends React.Component {
         let className = "component_path-element-wrapper";
         if(this.props.highlight) { className += " highlight"; }
 
-        let href = "/files" + (this.props.path.full || "")
+        let href = "files" + (this.props.path.full || "")
         href = href
             .replace(/\%/g, "%2525") // Hack to get the Link Component to work
                                      // See ExistingThing in 'thing-existing.js'
@@ -144,6 +144,7 @@ export class PathElementWrapper extends React.Component {
             .replace(/\?/g, "%3F");
         href = href || "/"
         href += location.search;
+        href = window.URL_PREFIX + "/" + href
 
         return (
             <div className={"li "+className}>

--- a/client/components/decorator.js
+++ b/client/components/decorator.js
@@ -81,7 +81,7 @@ export function ErrorPage(WrappedComponent){
                 const message = this.state.error.message || "There is nothing in here";
                 return (
                     <div>
-                      <Link onClick={this.navigate.bind(this)} to={`/${window.location.search}`} className="backnav">
+                      <Link onClick={this.navigate.bind(this)} to={`${window.URL_PREFIX}/${window.location.search}`} className="backnav">
                         <Icon name="arrow_left" />{ this.state.has_back_button ? "back" : "home" }
                       </Link>
                       <Container>

--- a/client/components/icon.js
+++ b/client/components/icon.js
@@ -39,25 +39,25 @@ import img_info from '../assets/img/info.svg';
 import img_fullscreen from '../assets/img/fullscreen.svg';
 import img_camera from '../assets/img/camera.svg';
 import img_location from '../assets/img/location.svg';
-export const img_placeholder = "/assets/icons/placeholder.png";
+export const img_placeholder = "assets/icons/placeholder.png";
 
 export const Icon = (props) => {
     if(props.name === null) return null;
     let img;
     if(props.name === 'directory'){
-        img = "/assets/icons/folder.svg";
+        img = "assets/icons/folder.svg";
     }else if(props.name === 'file'){
-        img = "/assets/icons/file.svg";
+        img = "assets/icons/file.svg";
     }else if(props.name === 'save'){
         img = img_save;
     }else if(props.name === 'power'){
         img = img_power;
     }else if(props.name === 'edit'){
-        img = "/assets/icons/edit.svg";
+        img = "assets/icons/edit.svg";
     }else if(props.name === 'delete'){
-        img = "/assets/icons/delete.svg";
+        img = "assets/icons/delete.svg";
     }else if(props.name === 'share'){
-        img = "/assets/icons/share.svg";
+        img = "assets/icons/share.svg";
     }else if(props.name === 'bucket'){
         img = img_bucket;
     }else if(props.name === 'download_white'){

--- a/client/helpers/navigate.js
+++ b/client/helpers/navigate.js
@@ -1,29 +1,29 @@
-export const URL_HOME = "/";
+export const URL_HOME = "";
 export function goToHome(history){
     history.push(URL_HOME);
     return Promise.resolve("ok");
 }
 
-export const URL_FILES = "/files";
+export const URL_FILES = "files";
 export function goToFiles(history, path, state){
     history.push(URL_FILES+"?path="+encode_path(path), state);
     return Promise.resolve("ok");
 }
 
 
-export const URL_VIEWER = "/view";
+export const URL_VIEWER = "view";
 export function goToViewer(history, path, state){
     history.push(URL_VIEWER+"?path="+encode_path(path), state);
     return Promise.resolve("ok");
 }
 
-export const URL_LOGIN = "/login";
+export const URL_LOGIN = "login";
 export function goToLogin(history){
     history.push(URL_EDIT);
     return Promise.resolve("ok");
 }
 
-export const URL_LOGOUT = "/logout";
+export const URL_LOGOUT = "logout";
 export function goToLogout(history){
     history.push(URL_LOGOUT);
     return Promise.resolve("ok");

--- a/client/index.html
+++ b/client/index.html
@@ -6,8 +6,8 @@
     <meta name="author" content="Mickael Kerjean <mickael@kerjean.me>">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <link rel="manifest" href="/assets/manifest.json">
-    <link rel="apple-touch-icon" href="/assets/logo/apple-touch-icon.png">
+    <link rel="manifest" href="assets/manifest.json">
+    <link rel="apple-touch-icon" href="assets/logo/apple-touch-icon.png">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="Filestash" name="apple-mobile-web-app-title">
     <meta content="black-translucent" name="apple-mobile-web-app-status-bar-style">
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#f2f3f5">
     <meta name="description" content="Manage your data in your cloud">
     <meta property="og:title" content="Filestash" />
-    <meta property="og:image" content="/assets/logo/og-image.png" />
+    <meta property="og:image" content="assets/logo/og-image.png" />
     <meta property="og:description" content="Manage your data in your cloud" />
   </head>
   <body>
@@ -26,7 +26,7 @@
         noscript div{ text-align:center;font-family:monospace;margin-top:5%;font-size:15px; }
       </style>
       <script>
-        if(location.pathname == "/" || location.pathname == "/login"){
+        if(location.href == document.baseURI || location.href == document.baseURI + "login"){
             $style = document.querySelector("div[role='main'] style");
             $style.innerText = $style.innerText.replace(/f2f3f5/g, "9AD1ED")
         }

--- a/client/index.js
+++ b/client/index.js
@@ -10,6 +10,7 @@ import './assets/css/reset.scss';
 window.addEventListener("DOMContentLoaded", () => {
     const className = 'ontouchstart' in window ? 'touch-yes' : 'touch-no';
     document.body.classList.add(className);
+    window.URL_PREFIX = document.baseURI.slice(window.location.origin.length, -1);
 
     const $loader = document.querySelector("#n-lder");
 
@@ -58,7 +59,7 @@ window.onerror = function (msg, url, lineNo, colNo, error) {
 
 if ("serviceWorker" in navigator) {
     window.addEventListener("load", function() {
-        navigator.serviceWorker.register("/sw_cache.js").catch(function(err){
+        navigator.serviceWorker.register("sw_cache.js").catch(function(err){
             console.error("ServiceWorker registration failed:", err);
         });
     });
@@ -68,7 +69,7 @@ if ("serviceWorker" in navigator) {
 window.overrides = {};
 function setup_xdg_open(){
     return new Promise((done, err) => {
-        load("/overrides/xdg-open.js", function(error) {
+        load("overrides/xdg-open.js", function(error) {
             if(error) return err(error);
             done()
         });

--- a/client/manifest.json
+++ b/client/manifest.json
@@ -3,12 +3,12 @@
     "short_name": "Filestash",
     "icons": [
         {
-            "src": "/assets/logo/android-chrome-192x192.png",
+            "src": "logo/android-chrome-192x192.png",
             "type": "image/png",
             "sizes": "192x192"
         },
         {
-            "src": "/assets/logo/android-chrome-512x512.png",
+            "src": "logo/android-chrome-512x512.png",
             "type": "image/png",
             "sizes": "512x512"
         }
@@ -17,5 +17,5 @@
     "background_color": "#f2f3f5",
     "orientation": "any",
     "display": "standalone",
-    "start_url": "/"
+    "start_url": ".."
 }

--- a/client/model/config.js
+++ b/client/model/config.js
@@ -34,7 +34,7 @@ class ConfigModel {
     }
 
     refresh(){
-        return http_get("/api/config").then((config) => {
+        return http_get("api/config").then((config) => {
             window.CONFIG = config.result;
         });
     }
@@ -52,7 +52,7 @@ class BackendModel {
     constructor(){}
 
     all(){
-        return http_get("/api/backend").then((r) => r.result);
+        return http_get("api/backend").then((r) => r.result);
     }
 }
 

--- a/client/model/files.js
+++ b/client/model/files.js
@@ -41,7 +41,7 @@ class FileSystem{
     }
 
     _ls_from_http(path, show_hidden){
-        const url = appendShareToUrl("/api/files/ls?path="+prepare(path));
+        const url = appendShareToUrl("api/files/ls?path="+prepare(path));
         return http_get(url).then((response) => {
             response = fileMiddleware(response, path, show_hidden);
 
@@ -88,7 +88,7 @@ class FileSystem{
             });
         }).catch((_err) => {
             if(_err.code === "Unauthorized"){
-                location = "/login?next="+location.pathname;
+                location = "login?next="+location.pathname;
             }
             this.obs.next(_err);
             return Promise.reject(err);
@@ -129,7 +129,7 @@ class FileSystem{
     }
 
     rm(path){
-        const url = appendShareToUrl('/api/files/rm?path='+prepare(path));
+        const url = appendShareToUrl('api/files/rm?path='+prepare(path));
         return this._replace(path, 'loading')
             .then((res) => this.current_path === dirname(path) ? this._ls_from_cache(dirname(path)) : Promise.resolve(res))
             .then(() => http_get(url))
@@ -148,7 +148,7 @@ class FileSystem{
     }
 
     cat(path){
-        const url = appendShareToUrl('/api/files/cat?path='+prepare(path));
+        const url = appendShareToUrl('api/files/cat?path='+prepare(path));
         return http_get(url, 'raw')
             .then((res) => {
                 if(this.is_binary(res) === true){
@@ -172,17 +172,17 @@ class FileSystem{
     }
 
     options(path){
-        const url = appendShareToUrl('/api/files/cat?path='+prepare(path));
+        const url = appendShareToUrl('api/files/cat?path='+prepare(path));
         return http_options(url);
     }
 
     url(path){
-        const url = appendShareToUrl('/api/files/cat?path='+prepare(path));
+        const url = appendShareToUrl('api/files/cat?path='+prepare(path));
         return Promise.resolve(url);
     }
 
     save(path, file){
-        const url = appendShareToUrl('/api/files/cat?path='+prepare(path));
+        const url = appendShareToUrl('api/files/cat?path='+prepare(path));
         let formData = new window.FormData();
         formData.append('file', file, "test");
         return this._replace(path, 'loading')
@@ -200,7 +200,7 @@ class FileSystem{
     }
 
     mkdir(path, step){
-        const url = appendShareToUrl('/api/files/mkdir?path='+prepare(path)),
+        const url = appendShareToUrl('api/files/mkdir?path='+prepare(path)),
               origin_path = pathBuilder(this.current_path, basename(path), 'directoy'),
               destination_path = path;
 
@@ -305,12 +305,12 @@ class FileSystem{
 
             function query(){
                 if(file){
-                    const url = appendShareToUrl('/api/files/cat?path='+prepare(path));
+                    const url = appendShareToUrl('api/files/cat?path='+prepare(path));
                     let formData = new window.FormData();
                     formData.append('file', file);
                     return http_post(url, formData, 'multipart');
                 }else{
-                    const url = appendShareToUrl('/api/files/touch?path='+prepare(path));
+                    const url = appendShareToUrl('api/files/touch?path='+prepare(path));
                     return http_get(url);
                 }
             }
@@ -326,7 +326,7 @@ class FileSystem{
     }
 
     mv(from, to){
-        const url = appendShareToUrl('/api/files/mv?from='+prepare(from)+"&to="+prepare(to)),
+        const url = appendShareToUrl('api/files/mv?from='+prepare(from)+"&to="+prepare(to)),
               origin_path = from,
               destination_path = to;
 
@@ -359,7 +359,7 @@ class FileSystem{
     }
 
     search(keyword, path = "/", show_hidden){
-        const url = appendShareToUrl("/api/files/search?path="+prepare(path)+"&q="+encodeURIComponent(keyword))
+        const url = appendShareToUrl("api/files/search?path="+prepare(path)+"&q="+encodeURIComponent(keyword))
         return http_get(url).then((response) => {
             response = fileMiddleware(response, path, show_hidden);
             return response.results;
@@ -468,7 +468,7 @@ class FileSystem{
 
 
 const createLink = (type, path) => {
-    return type === "file" ? "/view" + path : "/files" + path;
+    return type === "file" ? "view" + path : "files" + path;
 };
 
 const fileMiddleware = (response, path, show_hidden) => {

--- a/client/model/session.js
+++ b/client/model/session.js
@@ -2,7 +2,7 @@ import { http_get, http_post, http_delete } from '../helpers/';
 
 class SessionManager{
     currentUser(){
-        let url = '/api/session'
+        let url = 'api/session'
         return http_get(url)
             .then(data => data.result);
     }
@@ -13,13 +13,13 @@ class SessionManager{
     }
 
     authenticate(params){
-        let url = '/api/session';
+        let url = 'api/session';
         return http_post(url, params)
             .then(data => data.result);
     }
 
     logout(){
-        let url = '/api/session';
+        let url = 'api/session';
         return http_delete(url)
             .then(data => data.result);
     }

--- a/client/model/share.js
+++ b/client/model/share.js
@@ -4,7 +4,7 @@ class ShareModel {
     constructor(){}
 
     all(path = "/"){
-        const url = `/api/share?path=${path}`;
+        const url = `api/share?path=${path}`;
         return http_get(url).then((res) => res.results.map((el) => {
             if(el.can_read === true && el.can_write === false && el.can_upload === false){
                 el.role = "viewer";
@@ -20,24 +20,24 @@ class ShareModel {
     }
 
     get(id){
-        const url = `/api/share/${id}`;
+        const url = `api/share/${id}`;
         return http_get(url).then((res) => res.result);
     }
 
     upsert(obj){
-        const url = appendShareToUrl(`/api/share/${obj.id}`)
+        const url = appendShareToUrl(`api/share/${obj.id}`)
         const data = Object.assign({}, obj);
         delete data.role;
         return http_post(url, data);
     }
 
     remove(id){
-        const url = appendShareToUrl(`/api/share/${id}`);
+        const url = appendShareToUrl(`api/share/${id}`);
         return http_delete(url);
     }
 
     proof(id, data){
-        const url = `/api/share/${id}/proof`;
+        const url = `api/share/${id}/proof`;
         return http_post(url, data).then((res) => res.result);
     }
 }

--- a/client/pages/adminpage.js
+++ b/client/pages/adminpage.js
@@ -81,9 +81,9 @@ export class AdminPage extends React.Component {
 const SideMenu = (props) => {
     return (
         <div className="component_menu_sidebar no-select">
-          <NavLink to="/" className="header">
+          <NavLink to={window.URL_PREFIX + "/"} className="header">
             <Icon name="arrow_left" />
-            <img src="/assets/logo/android-chrome-512x512.png" />
+            <img src="assets/logo/android-chrome-512x512.png" />
           </NavLink>
           <h2>Admin console</h2>
           <ul>

--- a/client/pages/adminpage/home.js
+++ b/client/pages/adminpage/home.js
@@ -10,6 +10,6 @@ export class HomePage extends React.Component {
     }
 
     render(){
-        return ( <Redirect to="/admin/dashboard" /> );
+        return ( <Redirect to={window.URL_PREFIX+"/admin/dashboard"} /> );
     }
 }

--- a/client/pages/adminpage/setup.js
+++ b/client/pages/adminpage/setup.js
@@ -19,7 +19,7 @@ export class SetupPage extends React.Component {
     componentDidMount() {
         const start = (e) => {
             e.preventDefault();
-            this.props.history.push("/");
+            this.props.history.push("");
         };
 
         Config.all().then((config) => {

--- a/client/pages/connectpage.js
+++ b/client/pages/connectpage.js
@@ -46,7 +46,7 @@ export class ConnectPage extends React.Component {
                 if(location.search.indexOf("?next=") === 0){
                     location = urlParams()["next"];
                 }
-                let url = '/files/';
+                let url = 'files/';
                 let path = user.home;
                 if(path){
                     path = path.replace(/^\/?(.*?)\/?$/, "$1");

--- a/client/pages/filespage.js
+++ b/client/pages/filespage.js
@@ -31,10 +31,10 @@ export class FilesPage extends React.Component {
     constructor(props){
         super(props);
         if(props.match.url.slice(-1) != "/"){
-            this.props.history.push(props.match.url + "/");
+            this.props.history.push(window.URL_PREFIX + props.match.url + "/");
         }
         this.state = {
-            path: (decodeURIComponent(location.pathname).replace("/files", "") || "/" ),
+            path: (decodeURIComponent(location.pathname).replace(window.URL_PREFIX + "/files", "") || "/" ),
             sort: settings_get("filespage_sort") || "type",
             sort_reverse: true,
             show_hidden: settings_get("filespage_show_hidden") || CONFIG["display_hidden"],

--- a/client/pages/filespage/frequently_access.js
+++ b/client/pages/filespage/frequently_access.js
@@ -23,7 +23,7 @@ export class FrequentlyAccess extends React.Component {
                       {
                           this.props.files && this.props.files.map(function(path, index){
                               return (
-                                  <Link key={path} to={"/files"+path+window.location.search}>
+                                  <Link key={path} to={window.URL_PREFIX+"/files"+path+window.location.search}>
                                     <Icon name={'directory'} />
                                     <div>{Path.basename(path)}</div>
                                   </Link>

--- a/client/pages/filespage/share.js
+++ b/client/pages/filespage/share.js
@@ -210,10 +210,10 @@ export class ShareComponent extends React.Component {
                       this.state.existings && this.state.existings.map((link, i) => {
                           return (
                               <div className="link-details" key={i}>
-                                <span onClick={this.copyLinkInClipboard.bind(this, window.location.origin+"/s/"+link.id)} className="copy role">
+                                <span onClick={this.copyLinkInClipboard.bind(this, document.baseURI+"s/"+link.id)} className="copy role">
                                   {link.role}
                                 </span>
-                                <span onClick={this.copyLinkInClipboard.bind(this, window.location.origin+"/s/"+link.id)} className="copy path">{beautifulPath(this.props.path, link.path)}</span>
+                                <span onClick={this.copyLinkInClipboard.bind(this, document.baseURI+"s/"+link.id)} className="copy path">{beautifulPath(this.props.path, link.path)}</span>
                                 <Icon onClick={this.onDeleteLink.bind(this, link.id)} name="delete"/>
                                 <Icon onClick={this.onLoad.bind(this, link)} name="edit"/>
                               </div>
@@ -246,7 +246,7 @@ export class ShareComponent extends React.Component {
                 </div>
 
                 <div className="shared-link">
-                  <input ref="$input" className="copy" onClick={this.onRegisterLink.bind(this)} type="text" value={window.location.origin+"/s/"+(this.state.url || this.state.id)} onChange={() => {}}/>
+                  <input ref="$input" className="copy" onClick={this.onRegisterLink.bind(this)} type="text" value={document.baseURI+"s/"+(this.state.url || this.state.id)} onChange={() => {}}/>
                 </div>
               </NgIf>
             </div>

--- a/client/pages/filespage/thing-existing.js
+++ b/client/pages/filespage/thing-existing.js
@@ -248,7 +248,7 @@ export class ExistingThing extends React.Component {
 
         return connectDragSource(connectDropNativeFile(connectDropFile(
             <div className={"component_thing view-"+this.props.view+(this.props.selected === true ? " selected" : " not-selected")}>
-              <ToggleableLink onClick={this.onThingClick.bind(this)} to={fileLink + window.location.search} disabled={this.props.file.icon === "loading"}>
+              <ToggleableLink onClick={this.onThingClick.bind(this)} to={window.URL_PREFIX + "/" + fileLink + window.location.search} disabled={this.props.file.icon === "loading"}>
                 <Card ref="$card"className={this.state.hover} className={className}>
                   <Image preview={this.state.preview}
                          icon={this.props.file.icon || this.props.file.type}

--- a/client/pages/homepage.js
+++ b/client/pages/homepage.js
@@ -29,7 +29,7 @@ export class HomePage extends React.Component {
     }
     render() {
         if(this.state.redirection !== null){
-            return ( <Redirect to={this.state.redirection} /> );
+            return ( <Redirect to={`${window.URL_PREFIX}/${this.state.redirection}`} /> );
         }
         return ( <div> <Loader /> </div> );
     }

--- a/client/pages/logout.js
+++ b/client/pages/logout.js
@@ -14,7 +14,7 @@ export class LogoutPage extends React.Component {
         Session.logout()
             .then((res) => {
                 cache.destroy();
-                this.props.history.push('/login');
+                this.props.history.push('login');
             })
             .catch((err) => this.props.error(err));
     }

--- a/client/pages/notfoundpage.js
+++ b/client/pages/notfoundpage.js
@@ -23,7 +23,7 @@ export class NotFoundPage extends React.Component {
                 this.countdown();
             }, 1000);
         }else{
-            this.props.history.push("/");
+            this.props.history.push("");
         }
     }
 
@@ -33,7 +33,7 @@ export class NotFoundPage extends React.Component {
               <h1>Oops!</h1>
               <h2>We can't seem to find the page you're looking for.</h2>
               <p>
-                You will be redirected to the <Link to="/">homepage</Link> in {this.state.timeout} seconds
+                You will be redirected to the <Link to={window.URL_PREFIX + "/"}>homepage</Link> in {this.state.timeout} seconds
               </p>
             </div>
         );

--- a/client/pages/sharepage.js
+++ b/client/pages/sharepage.js
@@ -81,9 +81,9 @@ export class SharePage extends React.Component {
                 }
                 notify.send("You can't do that :)", "error");
             }else if(filetype(this.state.path) === "directory"){
-                return ( <Redirect to={`/files/?share=${this.state.share}`} /> );
+                return ( <Redirect to={`${window.URL_PREFIX}/files/?share=${this.state.share}`} /> );
             }else{
-                return ( <Redirect to={`/view/${basename(this.state.path)}?nav=false&share=${this.state.share}`} /> );
+                return ( <Redirect to={`${window.URL_PREFIX}/view/${basename(this.state.path)}?nav=false&share=${this.state.share}`} /> );
             }
         } else if (this.state.key === null){
             return (

--- a/client/pages/viewerpage.js
+++ b/client/pages/viewerpage.js
@@ -9,7 +9,7 @@ import { debounce, opener, notify } from '../helpers/';
 import { FileDownloader, ImageViewer, PDFViewer, FormViewer } from './viewerpage/';
 
 const VideoPlayer = (props) => (
-    <Bundle loader={import(/* webpackChunkName: "video" */"./viewerpage/videoplayer")} symbol="VideoPlayer" overrides={["/overrides/video-transcoder.js"]} >
+    <Bundle loader={import(/* webpackChunkName: "video" */"./viewerpage/videoplayer")} symbol="VideoPlayer" overrides={["overrides/video-transcoder.js"]} >
       {(Comp) => <Comp {...props}/>}
     </Bundle>
 );
@@ -36,9 +36,9 @@ export class ViewerPage extends React.Component {
     constructor(props){
         super(props);
         this.state = {
-            path: props.match.url.replace('/view', '').replace(/%23/g, "#") + (location.hash || ""),
+            path: props.match.url.replace(window.URL_PREFIX + '/view', '').replace(/%23/g, "#") + (location.hash || ""),
             url: null,
-            filename: Path.basename(props.match.url.replace('/view', '')) || 'untitled.dat',
+            filename: Path.basename(props.match.url.replace(window.URL_PREFIX + '/view', '')) || 'untitled.dat',
             opener: null,
             content: null,
             needSaving: false,
@@ -51,8 +51,8 @@ export class ViewerPage extends React.Component {
 
     componentWillReceiveProps(props){
         this.setState({
-            path: props.match.url.replace('/view', '').replace(/%23/g, "#") + (location.hash || ""),
-            filename: Path.basename(props.match.url.replace('/view', '')) || 'untitled.dat'
+            path: props.match.url.replace(window.URL_PREFIX + '/view', '').replace(/%23/g, "#") + (location.hash || ""),
+            filename: Path.basename(props.match.url.replace(window.URL_PREFIX + '/view', '')) || 'untitled.dat'
         }, () => { this.componentDidMount(); });
     }
 
@@ -130,7 +130,7 @@ export class ViewerPage extends React.Component {
     }
 
     onPathUpdate(path){
-        this.props.history.push('/files'+path);
+        this.props.history.push('files'+path);
     }
 
     needSaving(bool){

--- a/client/pages/viewerpage/editor/orgmode.js
+++ b/client/pages/viewerpage/editor/orgmode.js
@@ -255,7 +255,7 @@ function toggleHandler(cm, e){
             }else{
                 const root_path = dirname(window.location.pathname.replace(/^\/view/, ''));
                 const img_path = src;
-                $img.src = "/api/files/cat?path="+encodeURIComponent(pathBuilder(root_path, img_path));
+                $img.src = "api/files/cat?path="+encodeURIComponent(pathBuilder(root_path, img_path));
             }
             $el.appendChild($img);
             return $el;

--- a/client/pages/viewerpage/ide.js
+++ b/client/pages/viewerpage/ide.js
@@ -122,14 +122,14 @@ export class IDE extends React.Component {
                     </DropdownButton>
                     <DropdownList>
                       <DropdownItem name="na"><a download={this.props.filename} href={this.props.url}>Save current file</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"/api/export/"+(currentShare() || "private")+"/text/html"+this.props.path}>Export as HTML</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"/api/export/"+(currentShare() || "private")+"/application/pdf"+this.props.path}>Export as PDF</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"/api/export/"+(currentShare() || "private")+"/text/markdown"+this.props.path}>Export as Markdown</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"/api/export/"+(currentShare() || "private")+"/text/plain"+this.props.path}>Export as Text</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "tex")}  href={"/api/export/"+(currentShare() || "private")+"/text/x-latex"+this.props.path}>Export as Latex</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "ics")}  href={"/api/export/"+(currentShare() || "private")+"/text/calendar"+this.props.path}>Export as Calendar</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "odt")}  href={"/api/export/"+(currentShare() || "private")+"/application/vnd.oasis.opendocument.text"+this.props.path}>Export as Open office</a></DropdownItem>
-                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "pdf")}  href={"/api/export/"+(currentShare() || "private")+"/application/pdf"+this.props.path+"?mode=beamer"}>Export as Beamer</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"api/export/"+(currentShare() || "private")+"/text/html"+this.props.path}>Export as HTML</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"api/export/"+(currentShare() || "private")+"/application/pdf"+this.props.path}>Export as PDF</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"api/export/"+(currentShare() || "private")+"/text/markdown"+this.props.path}>Export as Markdown</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} href={"api/export/"+(currentShare() || "private")+"/text/plain"+this.props.path}>Export as Text</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "tex")}  href={"api/export/"+(currentShare() || "private")+"/text/x-latex"+this.props.path}>Export as Latex</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "ics")}  href={"api/export/"+(currentShare() || "private")+"/text/calendar"+this.props.path}>Export as Calendar</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "odt")}  href={"api/export/"+(currentShare() || "private")+"/application/vnd.oasis.opendocument.text"+this.props.path}>Export as Open office</a></DropdownItem>
+                      <DropdownItem name="na"><a target={this.props.needSaving ? "_blank" : "_self"} download={changeExt(this.props.filename, "pdf")}  href={"api/export/"+(currentShare() || "private")+"/application/pdf"+this.props.path+"?mode=beamer"}>Export as Beamer</a></DropdownItem>
                     </DropdownList>
                   </Dropdown>
 

--- a/client/pages/viewerpage/pager.js
+++ b/client/pages/viewerpage/pager.js
@@ -143,7 +143,7 @@ export class Pager extends React.Component {
             <div className="component_pager">
               <div className="wrapper no-select">
                 <NgIf cond={this.state.files.length > 0} type="inline">
-                  <Link to={prevLink()}><Icon name="arrow_left_white"/></Link>
+                  <Link to={window.URL_PREFIX + "/" + prevLink()}><Icon name="arrow_left_white"/></Link>
                   <label className="pager">
                     <form onSubmit={this.onFormSubmit.bind(this)}>
                       <input ref="$page" className="prevent" type="number" style={{width: inputWidth+"px"}} onChange={this.onFormInputChange.bind(this)} value={current_page_number} />
@@ -151,7 +151,7 @@ export class Pager extends React.Component {
                     <span className="separator">/</span>
                     <span ref="$total">{this.state.files.length}</span>
                   </label>
-                  <Link to={nextLink()}><Icon name="arrow_right_white"/></Link>
+                  <Link to={window.URL_PREFIX + "/" + nextLink()}><Icon name="arrow_right_white"/></Link>
                 </NgIf>
               </div>
             </div>

--- a/client/pages/viewerpage/videoplayer.js
+++ b/client/pages/viewerpage/videoplayer.js
@@ -13,6 +13,10 @@ import './videoplayer.scss';
 export class VideoPlayer extends React.Component {
     constructor(props){
         super(props);
+        videojs.Hls.xhr.beforeRequest = function(options) {
+            options.uri = options.uri.replace('/hls', window.URL_PREFIX + '/hls');
+            return options;
+        }
         if(!window.overrides["video-map-sources"]){
             window.overrides["video-map-sources"] = function(s){ return s; };
         }

--- a/client/router.js
+++ b/client/router.js
@@ -16,13 +16,13 @@ export default class AppRouter extends React.Component {
             <div style={{height: '100%'}}>
               <BrowserRouter>
                 <Switch>
-                  <Route exact path="/" component={HomePage} />
-                  <Route path="/s/:id*" component={SharePage} />
-                  <Route path="/login" component={ConnectPage} />
-                  <Route path="/files/:path*" component={FilesPage} />
-                  <Route path="/view/:path*" component={ViewerPage} />
-                  <Route path="/logout" component={LogoutPage} />
-                  <Route path="/admin" component={AdminPage} />
+                  <Route exact path={window.URL_PREFIX+"/"} component={HomePage} />
+                  <Route path={window.URL_PREFIX+"/s/:id*"} component={SharePage} />
+                  <Route path={window.URL_PREFIX+"/login"} component={ConnectPage} />
+                  <Route path={window.URL_PREFIX+"/files/:path*"} component={FilesPage} />
+                  <Route path={window.URL_PREFIX+"/view/:path*"} component={ViewerPage} />
+                  <Route path={window.URL_PREFIX+"/logout"} component={LogoutPage} />
+                  <Route path={window.URL_PREFIX+"/admin"} component={AdminPage} />
                   <Route component={NotFoundPage} />
                 </Switch>
               </BrowserRouter>

--- a/server/common/config.go
+++ b/server/common/config.go
@@ -290,6 +290,9 @@ func (this *Configuration) Initialise() {
 	if env := os.Getenv("APPLICATION_URL"); env != "" {
 		this.Get("general.host").Set(env).String()
 	}
+	if env := os.Getenv("URL_PREFIX"); env != "" {
+		this.Get("general.url_prefix").Set(env).String()
+	}
 	if this.Get("general.secret_key").String() == "" {
 		key := RandomString(16)
 		this.Get("general.secret_key").Set(key)

--- a/server/ctrl/admin.go
+++ b/server/ctrl/admin.go
@@ -68,7 +68,7 @@ func AdminSessionAuthenticate(ctx App, res http.ResponseWriter, req *http.Reques
 	http.SetCookie(res, &http.Cookie{
 		Name:   COOKIE_NAME_ADMIN,
 		Value:  obfuscate,
-		Path:   COOKIE_PATH_ADMIN,
+		Path:   Config.Get("general.url_prefix").String() + COOKIE_PATH_ADMIN,
 		MaxAge: 60*60, // valid for 1 hour
 		SameSite: http.SameSiteStrictMode,
 	})

--- a/server/ctrl/export.go
+++ b/server/ctrl/export.go
@@ -25,7 +25,7 @@ func FileExport(ctx App, res http.ResponseWriter, req *http.Request) {
 	query := req.URL.Query()
 	p := mux.Vars(req)
 	mimeType := fmt.Sprintf("%s/%s", p["mtype0"], p["mtype1"])
-	path, err := PathBuilder(ctx, strings.Replace(req.URL.Path, fmt.Sprintf("/api/export/%s/%s/%s", p["share"], p["mtype0"], p["mtype1"]), "", 1))
+	path, err := PathBuilder(ctx, strings.TrimPrefix(req.URL.Path, Config.Get("general.url_prefix").String() + fmt.Sprintf("/api/export/%s/%s/%s", p["share"], p["mtype0"], p["mtype1"])))
 	if err != nil {
 		SendErrorResult(res, err)
 		return

--- a/server/ctrl/session.go
+++ b/server/ctrl/session.go
@@ -81,7 +81,7 @@ func SessionAuthenticate(ctx App, res http.ResponseWriter, req *http.Request) {
 		Name:     COOKIE_NAME_AUTH,
 		Value:    obfuscate,
 		MaxAge:   60 * 60 * 24 * 30,
-		Path:     COOKIE_PATH,
+		Path:     Config.Get("general.url_prefix").String() + COOKIE_PATH,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
 	})
@@ -103,19 +103,19 @@ func SessionLogout(ctx App, res http.ResponseWriter, req *http.Request) {
 		Name:   COOKIE_NAME_AUTH,
 		Value:  "",
 		MaxAge: -1,
-		Path:   COOKIE_PATH,
+		Path:   Config.Get("general.url_prefix").String() + COOKIE_PATH,
 	})
 	http.SetCookie(res, &http.Cookie{
 		Name:   COOKIE_NAME_ADMIN,
 		Value:  "",
 		MaxAge: -1,
-		Path:   COOKIE_PATH_ADMIN,
+		Path:   Config.Get("general.url_prefix").String() + COOKIE_PATH_ADMIN,
 	})
 	http.SetCookie(res, &http.Cookie{
 		Name:   COOKIE_NAME_PROOF,
 		Value:  "",
 		MaxAge: -1,
-		Path:   COOKIE_PATH,
+		Path:   Config.Get("general.url_prefix").String() + COOKIE_PATH,
 	})
 	SendSuccessResult(res, nil)
 }

--- a/server/ctrl/share.go
+++ b/server/ctrl/share.go
@@ -121,7 +121,7 @@ func ShareVerifyProof(ctx App, res http.ResponseWriter, req *http.Request) {
 			Name:   COOKIE_NAME_PROOF,
 			Value:  "",
 			MaxAge: -1,
-			Path:   COOKIE_PATH,
+			Path:   Config.Get("general.url_prefix").String() + COOKIE_PATH,
 		})
 		SendErrorResult(res, ErrNotValid)
 		return
@@ -161,7 +161,7 @@ func ShareVerifyProof(ctx App, res http.ResponseWriter, req *http.Request) {
 			str, _ := EncryptString(SECRET_KEY_DERIVATE_FOR_PROOF, string(j))
 			return str
 		}(verifiedProof),
-		Path: COOKIE_PATH,
+		Path: Config.Get("general.url_prefix").String() + COOKIE_PATH,
 		MaxAge: 60 * 60 * 24 * 30,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,

--- a/server/main.go
+++ b/server/main.go
@@ -22,7 +22,9 @@ func main() {
 
 func Init(a *App) {
 	var middlewares []Middleware
-	r := mux.NewRouter()
+	toplevel_router := mux.NewRouter()
+
+	var r = toplevel_router.PathPrefix(Config.Get("general.url_prefix").String()).Subrouter()
 
 	// API for Session
 	session := r.PathPrefix("/api/session").Subrouter()
@@ -113,7 +115,7 @@ func Init(a *App) {
 	// fancy I don't know much when this got written: IPFS, solid, ...
 	Log.Info("Filestash %s starting", APP_VERSION)
 	for _, obj := range Hooks.Get.Starter() {
-		go obj(r)
+		go obj(toplevel_router)
 	}
 	if len(Hooks.Get.Starter()) == 0 {
 		Log.Warning("No starter plugin available")

--- a/server/middleware/index.go
+++ b/server/middleware/index.go
@@ -68,7 +68,7 @@ type LogEntry struct {
 }
 
 func Logger(ctx App, res http.ResponseWriter, req *http.Request) {
-	if obj, ok := res.(*ResponseWriter); ok && req.RequestURI != "/about" {
+	if obj, ok := res.(*ResponseWriter); ok && req.RequestURI != Config.Get("general.url_prefix").String() + "/about" {
 		point := LogEntry{
 			Version:    APP_VERSION,
 			Scheme:     req.URL.Scheme,

--- a/server/model/backend/gdrive.go
+++ b/server/model/backend/gdrive.go
@@ -34,7 +34,7 @@ func (g GDrive) Init(params map[string]string, app *App) (IBackend, error) {
 		Endpoint:     google.Endpoint,
 		ClientID:     Config.Get("auth.gdrive.client_id").Default(os.Getenv("GDRIVE_CLIENT_ID")).String(),
 		ClientSecret: Config.Get("auth.gdrive.client_secret").Default(os.Getenv("GDRIVE_CLIENT_SECRET")).String(),
-		RedirectURL:  "https://" + Config.Get("general.host").String() + "/login",
+		RedirectURL:  "https://" + Config.Get("general.host").String() + Config.Get("general.url_prefix").String() + "/login",
 		Scopes:       []string{"https://www.googleapis.com/auth/drive"},
 	}
 	if config.ClientID == "" {

--- a/server/plugin/plg_editor_onlyoffice/index.go
+++ b/server/plugin/plg_editor_onlyoffice/index.go
@@ -77,7 +77,7 @@ func init() {
 		oods.HandleFunc("/content", FetchContentHandler).Methods("GET")
 
 		r.HandleFunc(
-			COOKIE_PATH + "onlyoffice/iframe",
+			Config.Get("general.url_prefix").String() + COOKIE_PATH + "onlyoffice/iframe",
 			NewMiddlewareChain(
 				IframeContentHandler,
 				[]Middleware{ SessionStart, LoggedInOnly },
@@ -98,7 +98,7 @@ func init() {
 }
 
 func StaticHandler(res http.ResponseWriter, req *http.Request) {
-	req.URL.Path = strings.TrimPrefix(req.URL.Path, "/onlyoffice/static")
+	req.URL.Path = strings.TrimPrefix(req.URL.Path, Config.Get("general.url_prefix").String() + "/onlyoffice/static")
 	oodsLocation := Config.Get("features.office.onlyoffice_server").String()
 	u, err := url.Parse(oodsLocation)
 	if err != nil {

--- a/server/plugin/plg_handler_console/index.go
+++ b/server/plugin/plg_handler_console/index.go
@@ -45,7 +45,7 @@ func init() {
 		r.PathPrefix("/tty/").Handler(
 			AuthBasic(
 				func() (string, string) { return "admin", Config.Get("auth.admin").String() },
-				TTYHandler("/tty/"),
+				TTYHandler(Config.Get("general.url_prefix").String() + "/tty/"),
 			),
 		)
 		return nil

--- a/server/plugin/plg_handler_syncthing/index.go
+++ b/server/plugin/plg_handler_syncthing/index.go
@@ -55,7 +55,7 @@ func init() {
 			return nil
 		}
 		r.HandleFunc(SYNCTHING_URI, func (res http.ResponseWriter, req *http.Request) {
-			http.Redirect(res, req, SYNCTHING_URI + "/", http.StatusTemporaryRedirect)
+			http.Redirect(res, req, Config.Get("general.url_prefix").String() + SYNCTHING_URI + "/", http.StatusTemporaryRedirect)
 		})
 		r.Handle(SYNCTHING_URI + "/", AuthBasic(
 			func() (string, string) { return "admin", Config.Get("auth.admin").String() },
@@ -110,7 +110,7 @@ func AuthBasic(credentials func() (string, string), fn http.Handler) http.Handle
 }
 
 func SyncthingProxyHandler(res http.ResponseWriter, req *http.Request) {
-	req.URL.Path = strings.TrimPrefix(req.URL.Path, SYNCTHING_URI)
+	req.URL.Path = strings.TrimPrefix(req.URL.Path, Config.Get("general.url_prefix").String() + SYNCTHING_URI)
 	req.Header.Set("X-Forwarded-Host", req.Host + SYNCTHING_URI)
 	req.Header.Set("X-Forwarded-Proto", func() string {
 		if scheme := req.Header.Get("X-Forwarded-Proto"); scheme != "" {

--- a/server/plugin/plg_starter_http/index.go
+++ b/server/plugin/plg_starter_http/index.go
@@ -17,7 +17,7 @@ func init() {
 			Addr:    fmt.Sprintf(":%d", port),
 			Handler: r,
 		}
-		go ensureAppHasBooted(fmt.Sprintf("http://127.0.0.1:%d/about", port), fmt.Sprintf("[http] listening on :%d", port))
+		go ensureAppHasBooted(fmt.Sprintf("http://127.0.0.1:%d%s/about", Config.Get("general.url_prefix").String(), port), fmt.Sprintf("[http] listening on :%d", port))
 		go func() {
 			if err := srv.ListenAndServe(); err != nil {
 				Log.Error("error: %v", err)

--- a/server/plugin/plg_starter_http2/index.go
+++ b/server/plugin/plg_starter_http2/index.go
@@ -81,7 +81,7 @@ func init() {
 				return
 			}
 		}()
-		go ensureAppHasBooted("https://127.0.0.1/about", fmt.Sprintf("[https] started"))
+		go ensureAppHasBooted("https://127.0.0.1" + Config.Get("general.url_prefix").String() + "/about", fmt.Sprintf("[https] started"))
 	})
 }
 

--- a/server/plugin/plg_starter_https/index.go
+++ b/server/plugin/plg_starter_https/index.go
@@ -76,7 +76,7 @@ func init() {
 				return
 			}
 		}()
-		go ensureAppHasBooted("https://127.0.0.1/about", fmt.Sprintf("[https] started"))
+		go ensureAppHasBooted("https://127.0.0.1" + Config.Get("general.url_prefix").String() + "/about", fmt.Sprintf("[https] started"))
 	})
 }
 

--- a/server/plugin/plg_starter_tunnel/index.go
+++ b/server/plugin/plg_starter_tunnel/index.go
@@ -58,7 +58,7 @@ func init() {
 			Addr:    ":8334",
 			Handler: r,
 		}
-		go ensureAppHasBooted("http://127.0.0.1:8334/about", "[http] listening on :8334")
+		go ensureAppHasBooted("http://127.0.0.1:8334" + Config.Get("general.url_prefix").String() + "/about", "[http] listening on :8334")
 		go func() {
 			if err := srv.ListenAndServe(); err != nil {
 				Log.Error("error: %v", err)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ let config = {
     },
     output: {
         path: path.join(__dirname, 'dist', 'data', 'public'),
-        publicPath: '/',
+        publicPath: '',
         filename: 'assets/js/[name]_[chunkhash].js',
         chunkFilename: "assets/js/chunk_[name]_[id]_[chunkhash].js"
     },


### PR DESCRIPTION
This PR addresses #168.

The `general.url_prefix` configuration option is added to run filestash at a location that is not the root of the domain. The prefix should be specified with a leading slash and no trailing slash. Leaving this option empty corresponds to previous behavior.

The option `general.url_prefix` can also be set though the `URL_PREFIX` environment variable.

The backend rewrites `index.html` to include a `<base>` tag which informs the frontend about the url prefix. The downside of this approach is that `index.html` cannot be cached or compressed.

This feature should be considered experimental. I have tested the basic functionality but I can't guarantee that everything will still work so it probably requires more testing.