### PR TITLE
Allow users to set custom css without building filestash

### DIFF
--- a/client/assets/css/custom.css
+++ b/client/assets/css/custom.css
@@ -1,0 +1,1 @@
+/* This file can contain user css overrides */

--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,7 @@
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link rel="manifest" href="/assets/manifest.json">
     <link rel="apple-touch-icon" href="/assets/logo/apple-touch-icon.png">
+    <link rel="stylesheet" href="/assets/custom.css">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="Filestash" name="apple-mobile-web-app-title">
     <meta content="black-translucent" name="apple-mobile-web-app-status-bar-style">

--- a/server/middleware/http.go
+++ b/server/middleware/http.go
@@ -48,7 +48,7 @@ func IndexHeaders(fn func(App, http.ResponseWriter, *http.Request)) func(ctx App
 		header.Set("X-Powered-By", fmt.Sprintf("Filestash/%s.%s <https://filestash.app>", APP_VERSION, BUILD_DATE))
 
 		cspHeader := "default-src 'none'; "
-		cspHeader += "style-src 'unsafe-inline'; "
+		cspHeader += "style-src 'self' 'unsafe-inline'; "
 		cspHeader += "font-src 'self' data:; "
 		cspHeader += "manifest-src 'self'; "
 		cspHeader += "script-src 'self' 'sha256-JNAde5CZQqXtYRLUk8CGgyJXo6C7Zs1lXPPClLM1YM4=' 'sha256-9/gQeQaAmVkFStl6tfCbHXn8mr6PgtxlH+hEp685lzY=' 'sha256-ER9LZCe8unYk8AJJ2qopE+rFh7OUv8QG5q3h6jZeoSk='; "

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,6 +72,7 @@ let config = {
             { from: "assets/logo/*" },
             { from: "assets/icons/*" },
             { from: "assets/fonts/*" },
+            { from: "assets/css/custom.css", to: "assets/" },
         ], { context: path.join(__dirname, 'client') }),
         new CopyWebpackPlugin([
             { from: "node_modules/pdfjs-dist/", to: "assets/vendor/pdfjs"}


### PR DESCRIPTION
Personally, I do not like the padding in the image viewer.
This is just a simple CSS setting. With this merge request, I can override ths padding without building filestash itself.

In this example i would have a custom.css in my local file system like this:
```css
.component_image_container {
  padding: 0px !important;
}
```

This is then mounted to the docker container with `-v /home/user/filestash/custom.css:/app/data/public/assets/custom.css`