### PR TITLE
Allow users to set custom css in admin panel

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,6 +8,7 @@
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link rel="manifest" href="/assets/manifest.json">
     <link rel="apple-touch-icon" href="/assets/logo/apple-touch-icon.png">
+    <link rel="stylesheet" href="/custom.css">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="Filestash" name="apple-mobile-web-app-title">
     <meta content="black-translucent" name="apple-mobile-web-app-status-bar-style">

--- a/server/common/config.go
+++ b/server/common/config.go
@@ -78,6 +78,7 @@ func NewConfiguration() Configuration {
 					FormElement{Name: "auto_connect", Type: "boolean", Default: false, Description: "User don't have to click on the login button if an admin is prefilling a unique backend"},
 					FormElement{Name: "remember_me", Type: "boolean", Default: true, Description: "Visiblity of the remember me button on the login screen"},
 					FormElement{Name: "upload_button", Type: "boolean", Default: false, Description: "Display the upload button on any device"},
+					FormElement{Name: "custom_css", Type: "long_text", Default: "", Description: "Set custom css code for your instance"},
 				},
 			},
 			Form{

--- a/server/ctrl/static.go
+++ b/server/ctrl/static.go
@@ -91,6 +91,11 @@ func AboutHandler(ctx App, res http.ResponseWriter, req *http.Request) {
 	}})
 }
 
+func CustomCssHandler(ctx App, res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Content-Type", "text/css");
+	io.WriteString(res, Config.Get("general.custom_css").String());
+}
+
 func ServeFile(res http.ResponseWriter, req *http.Request, filePath string) {
 	zFilePath := filePath + ".gz"
 	bFilePath := filePath + ".br"

--- a/server/main.go
+++ b/server/main.go
@@ -101,6 +101,7 @@ func Init(a *App) {
 	})
 	r.HandleFunc("/.well-known/security.txt", NewMiddlewareChain(WellKnownSecurityHandler, []Middleware{}, *a)).Methods("GET")
 	r.HandleFunc("/healthz", NewMiddlewareChain(HealthHandler, []Middleware{}, *a)).Methods("GET")
+	r.HandleFunc("/custom.css", NewMiddlewareChain(CustomCssHandler, []Middleware{}, *a)).Methods("GET")
 
 	if os.Getenv("DEBUG") == "true" {
 		initDebugRoutes(r)

--- a/server/middleware/http.go
+++ b/server/middleware/http.go
@@ -48,7 +48,7 @@ func IndexHeaders(fn func(App, http.ResponseWriter, *http.Request)) func(ctx App
 		header.Set("X-Powered-By", fmt.Sprintf("Filestash/%s.%s <https://filestash.app>", APP_VERSION, BUILD_DATE))
 
 		cspHeader := "default-src 'none'; "
-		cspHeader += "style-src 'unsafe-inline'; "
+		cspHeader += "style-src 'self' 'unsafe-inline'; "
 		cspHeader += "font-src 'self' data:; "
 		cspHeader += "manifest-src 'self'; "
 		cspHeader += "script-src 'self' 'sha256-JNAde5CZQqXtYRLUk8CGgyJXo6C7Zs1lXPPClLM1YM4=' 'sha256-9/gQeQaAmVkFStl6tfCbHXn8mr6PgtxlH+hEp685lzY=' 'sha256-ER9LZCe8unYk8AJJ2qopE+rFh7OUv8QG5q3h6jZeoSk='; "


### PR DESCRIPTION
This is a reimplementation based on the comments in https://github.com/mickael-kerjean/filestash/pull/323

Personally, I do not like the padding in the image viewer.
This is just a simple CSS setting. With this merge request, I can override this padding without building filestash itself.

In this example i would the css in the admin panel like this:
```css
.component_image_container {
  padding: 0px !important;
}
```