### PR TITLE
Add support for ASS/SSA subtitles

### DIFF
--- a/client/pages/viewerpage.js
+++ b/client/pages/viewerpage.js
@@ -96,21 +96,19 @@ export class ViewerPage extends React.Component {
                 const currentDirectory = this.state.path.substr(0, this.state.path.lastIndexOf("/") + 1);
                 const videoFileWithoutExt = this.state.filename.substr(0, this.state.filename.lastIndexOf("."));
                 const subtitlesTracks = [videoFileWithoutExt + ".ssa", videoFileWithoutExt + ".ass"];
-                var searchPromises = [];
+                var catPromises = [];
                 for (const subtitlesTrack of subtitlesTracks) {
-                    searchPromises.push(Files.search(subtitlesTrack, currentDirectory));
+                    catPromises.push(Files.cat(currentDirectory + subtitlesTrack));
                 }
-                return Promise.all(searchPromises).then((allSearchResults) => {
-                    for (const searchResults of allSearchResults) {
-                        if (Array.isArray(searchResults) && searchResults.length > 0) {
-                            Files.url(searchResults[0].path).then((subtitlesTrackUrl) => {
-                                this.setState({
-                                    subtitlesTrack: subtitlesTrackUrl,
-                                    loading: false
-                                });
+                return Promise.allSettled(catPromises).then((catResults) => {
+                    for (let i = 0; i < subtitlesTracks.length; i++) {
+                        if (catResults[i].status === "fulfilled") {
+                            Files.url(currentDirectory + subtitlesTracks[i]).then(url => {
+                                this.setState({subtitlesTrack: url});
                             });
                         }
                     }
+                    this.setState({loading: false});
                 });
             }
             this.setState({loading: false});

--- a/client/pages/viewerpage/videoplayer.js
+++ b/client/pages/viewerpage/videoplayer.js
@@ -27,12 +27,14 @@ export class VideoPlayer extends React.Component {
             }])
         });
 
-        const subtitlesOctopusScript = document.createElement("script");
-        subtitlesOctopusScript.src = "/assets/vendor/libass-wasm/subtitles-octopus.js";
-        subtitlesOctopusScript.async = true;
-        subtitlesOctopusScript.onload = () => this.subtitlesOctopusInstantiate();
+        if (this.props.subtitlesTrack !== null) {
+            const subtitlesOctopusScript = document.createElement("script");
+            subtitlesOctopusScript.src = "/assets/vendor/libass-wasm/subtitles-octopus.js";
+            subtitlesOctopusScript.async = true;
+            subtitlesOctopusScript.onload = () => this.subtitlesOctopusInstantiate();
 
-        document.head.appendChild(subtitlesOctopusScript);
+            document.head.appendChild(subtitlesOctopusScript);
+        }
     }
 
     subtitlesOctopusInstantiate() {

--- a/client/pages/viewerpage/videoplayer.js
+++ b/client/pages/viewerpage/videoplayer.js
@@ -26,6 +26,23 @@ export class VideoPlayer extends React.Component {
                 type: getMimeType(this.props.data)
             }])
         });
+	
+	const subtitlesOctopusScript = document.createElement("script");
+	subtitlesOctopusScript.src = "/assets/vendor/libass-wasm/subtitles-octopus.js";
+	subtitlesOctopusScript.async = true;
+	subtitlesOctopusScript.onload = () => this.subtitlesOctopusInstantiate();
+
+	document.head.appendChild(subtitlesOctopusScript);
+    }
+
+    subtitlesOctopusInstantiate() {
+	var options = {
+    	    video: this.refs.$video,
+    	    subUrl: this.props.data.substr(0, this.props.data.lastIndexOf(".")) + ".ass",
+    	    workerUrl: '/assets/vendor/libass-wasm/subtitles-octopus-worker.js',
+    	    legacyWorkerUrl: '/assets/vendor/libass-wasm/subtitles-octopus-worker-legacy.js'
+	};
+	var instance = new SubtitlesOctopus(options);
     }
 
     componentWillReceiveProps(nextProps){

--- a/client/pages/viewerpage/videoplayer.js
+++ b/client/pages/viewerpage/videoplayer.js
@@ -26,23 +26,23 @@ export class VideoPlayer extends React.Component {
                 type: getMimeType(this.props.data)
             }])
         });
-	
-	const subtitlesOctopusScript = document.createElement("script");
-	subtitlesOctopusScript.src = "/assets/vendor/libass-wasm/subtitles-octopus.js";
-	subtitlesOctopusScript.async = true;
-	subtitlesOctopusScript.onload = () => this.subtitlesOctopusInstantiate();
 
-	document.head.appendChild(subtitlesOctopusScript);
+        const subtitlesOctopusScript = document.createElement("script");
+        subtitlesOctopusScript.src = "/assets/vendor/libass-wasm/subtitles-octopus.js";
+        subtitlesOctopusScript.async = true;
+        subtitlesOctopusScript.onload = () => this.subtitlesOctopusInstantiate();
+
+        document.head.appendChild(subtitlesOctopusScript);
     }
 
     subtitlesOctopusInstantiate() {
-	var options = {
-    	    video: this.refs.$video,
-    	    subUrl: this.props.data.substr(0, this.props.data.lastIndexOf(".")) + ".ass",
-    	    workerUrl: '/assets/vendor/libass-wasm/subtitles-octopus-worker.js',
-    	    legacyWorkerUrl: '/assets/vendor/libass-wasm/subtitles-octopus-worker-legacy.js'
-	};
-	var instance = new SubtitlesOctopus(options);
+        const options = {
+            video: this.refs.$video,
+            subUrl: this.props.subtitlesTrack,
+            workerUrl: '/assets/vendor/libass-wasm/subtitles-octopus-worker.js',
+            legacyWorkerUrl: '/assets/vendor/libass-wasm/subtitles-octopus-worker-legacy.js'
+        };
+        const instance = new SubtitlesOctopus(options);
     }
 
     componentWillReceiveProps(nextProps){

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bcryptjs": "^2.4.3",
     "codemirror": "^5.26.0",
     "exif-js": "^2.3.0",
+    "libass-wasm": "^4.0.0",
     "little-loader": "^0.2.0",
     "pdfjs-dist": "^2.1.266",
     "prop-types": "^15.5.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,9 @@ let config = {
         new CopyWebpackPlugin([
             { from: "node_modules/pdfjs-dist/", to: "assets/vendor/pdfjs"}
         ]),
+        new CopyWebpackPlugin([
+            { from: "node_modules/libass-wasm/dist/js/", to: "assets/vendor/libass-wasm"}
+        ]),
         //new BundleAnalyzerPlugin()
     ]
 };


### PR DESCRIPTION
This PR uses [SubtitlesOctopus](https://github.com/Dador/JavascriptSubtitlesOctopus) to detect and play ASS and SSA subtitles tracks in the browser.

This library is also used by [Jellyfin](https://github.com/jellyfin/jellyfin-web).

I wasn't sure how to properly implement this, I believe the current architecture is decent but I am still open to suggestions.
The detection of subtitles files is done with the `Files.cat` method because it was the fastest, and the results of `search` didn't look consistent enough depending on whether the indexer was enabled or disabled.