### PR TITLE
fix bug #356 preventing entering the expiration date on safari

### DIFF
--- a/client/pages/filespage/share.js
+++ b/client/pages/filespage/share.js
@@ -182,9 +182,15 @@ export class ShareComponent extends React.Component {
         };
         const datify = function(str){
             if(!str) return str;
-            const d = new Date(str);
-            const pad = (a) => a.toString().length === 1 ? "0"+a : a;
-            return [d.getFullYear(), pad(d.getMonth()), pad(d.getDate())].join("-");
+            const d = new Date(str); 
+
+            // old browser not implementing input[type=date] elements
+            // may return invalid date,
+            if(isNaN(d.getDate())) return str;
+            
+            const pad2 = (a) => ("00"+a).slice(-2);
+            const pad4 = (a) => ("0000"+a).slice(-4);
+            return [pad4(d.getFullYear()), pad2(d.getMonth()+1), pad2(d.getDate())].join("-");
         };
 
         return (


### PR DESCRIPTION
This is fixing 3 potential problems:
* safari does not implement input[type=date] element so the value of the input may be an invalid date. In this case we simply return the string as is, since the user is probably writing it. (fixes #356)
* In other (real) browsers, if we change "by hand" the year, then it could be a small interger (for instance "2" if we are currently writing 2021), so in order to preserve a valid date, the year should be padded with "0" (otherwise, the date becomes invalid and the browser resets the date).
* getMonth starts from 0, so we need to add 1 to have back the string representation of the full date. (that is why it is not working using the datepicker if you choose a date in January)