### PR TITLE
Corrected URL typo - added trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 </p>
 
 # Documentation
-- [Getting started](https://www.filestash.app/docs)
+- [Getting started](https://www.filestash.app/docs/)
 - [Installation](https://www.filestash.app/docs/install-and-upgrade/)
 - [FAQ](https://www.filestash.app/docs/faq/)
 


### PR DESCRIPTION
https://www.filestash.app/docs leads to forbidden