### PR TITLE
Limit memory usage when parsing multipart form data.

### DIFF
--- a/server/ctrl/files.go
+++ b/server/ctrl/files.go
@@ -5,15 +5,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"hash/fnv"
-	. "github.com/mickael-kerjean/filestash/server/common"
-	"github.com/mickael-kerjean/filestash/server/model"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"strconv"
+	"strings"
 	"time"
+
+	. "github.com/mickael-kerjean/filestash/server/common"
+	"github.com/mickael-kerjean/filestash/server/model"
 )
 
 type FileInfo struct {
@@ -300,6 +301,13 @@ func FileSave(ctx App, res http.ResponseWriter, req *http.Request) {
 		SendErrorResult(res, err)
 		return
 	}
+
+	maxMemory := int64(32 << 20) // 32MB
+	err = req.ParseMultipartForm(maxMemory)
+    if err != nil {
+		SendErrorResult(res, err)
+		return
+    }
 
 	file, _, err := req.FormFile("file")
 	if err != nil {


### PR DESCRIPTION
When you upload large files, it could be better to save the form data in disk temporary instead of entirely in memory.
Fortunately, go already take this into account by calling the right function.

With this I was able to upload large files (eg. 3.5Go) in a very small development server (0.5Go Ram, 1vCpu) (off course by having appropriate nginx config such as large client_max_body_size)