### PR TITLE
fix(zip): close file after copying to zip

### DIFF
--- a/server/ctrl/files.go
+++ b/server/ctrl/files.go
@@ -457,6 +457,7 @@ func FileDownloader(ctx App, res http.ResponseWriter, req *http.Request) {
 				io.Copy(zipFile, strings.NewReader(""))
 				return err
 			}
+			file.Close()
 			return nil
 		}
 		// Process Folder


### PR DESCRIPTION
I finally found the reason why I got `SSH_FX_FAILURE` when downloading folders with many files: the files are not closed. This 1-line change fixes this.