### PR TITLE
Use No-X11 version of emacs (currently GTK)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update > /dev/null && \
     apt-get purge -y --auto-remove gnupg && \
     #################
     # Optional dependencies
-    apt-get install -y curl tor emacs ffmpeg zip poppler-utils > /dev/null && \
+    apt-get install -y curl tor emacs-nox ffmpeg zip poppler-utils > /dev/null && \
     # org-mode: html export
     curl https://raw.githubusercontent.com/mickael-kerjean/filestash/master/server/.assets/emacs/htmlize.el > /usr/share/emacs/site-lisp/htmlize.el && \
     # org-mode: markdown export


### PR DESCRIPTION
Surely this is more in line with the package goals, or is there a reason to install X for emacs support?