### PR TITLE
Add Working directory override

### DIFF
--- a/server/common/files.go
+++ b/server/common/files.go
@@ -12,6 +12,9 @@ func GetCurrentDir() string {
 	if MOCK_CURRENT_DIR != "" {
 		return MOCK_CURRENT_DIR
 	}
+	if os.Getenv("WORK_DIR") != "" {
+		return os.Getenv("WORK_DIR")
+	}
 	ex, _ := os.Executable()
 	return filepath.Dir(ex)
 }


### PR DESCRIPTION
Hello,

It would be great if the working directory could be configurable, giving the user the freedom of placing the files generated at runtime in a different place than the executable. 

I've added an environment variable which can be set to override the directory returned by `GetCurrentDir`. I saw you already have a [MOCK_CURRENT_DIR](https://github.com/mickael-kerjean/filestash/blob/cddbcfc6d1e71e6146ba36e9c91ff38e1afd6165/server/common/files.go#L9) variable there, but I can't find any places where it is actually set.

I'm trying to make the application runnable on NixOS, where the location of the installed binary (nix store) is not writable and runtime files will have to be placed somewhere else.