### PR TITLE
Recursive S3 Mv

### DIFF
--- a/server/plugin/plg_backend_s3/index.go
+++ b/server/plugin/plg_backend_s3/index.go
@@ -321,10 +321,12 @@ func (s S3Backend) Mv(from string, to string) error {
 		},
 		func(objs *s3.ListObjectsV2Output, lastPage bool) bool {
 			for _, obj := range objs.Contents {
+				from := f.bucket + "/" + *obj.Key
+				toKey := t.path + strings.TrimPrefix(*obj.Key, f.path)
 				input := &s3.CopyObjectInput{
-					CopySource: aws.String(f.bucket + "/" + f.path + "/" + *obj.Key),
+					CopySource: aws.String(from),
 					Bucket:     aws.String(t.bucket),
-					Key:        aws.String(t.path + "/" + *obj.Key),
+					Key:        aws.String(toKey),
 				}
 				if s.params["encryption_key"] != "" {
 					input.CopySourceSSECustomerAlgorithm = aws.String("AES256")
@@ -332,28 +334,42 @@ func (s S3Backend) Mv(from string, to string) error {
 					input.SSECustomerAlgorithm = aws.String("AES256")
 					input.SSECustomerKey = aws.String(s.params["encryption_key"])
 				}
+
+				Log.Debug("CopyObject(%s, %s):", from, f.bucket + "/" + toKey)
 				_, err := client.CopyObject(input)
 				if err != nil {
+					Log.Error("CopyObject from: %s to: %s",
+						f.bucket + "/" + *obj.Key,
+						t.bucket + "/" + t.path + *obj.Key,
+						err)
 					return false
 				}
 			
+				Log.Debug("DeleteObject(%s):", f.bucket + "/" + *obj.Key)
 				_, err = client.DeleteObject(&s3.DeleteObjectInput{
 					Bucket: aws.String(f.bucket),
 					Key:    obj.Key,
 				})
 				if err != nil {
+					Log.Error("DeleteObject failed: %s", *obj.Key, err)
 					return false
 				}
 			}
 			for _, pref := range objs.CommonPrefixes {
-				err := s.Mv("/" + f.bucket + "/" + *pref.Prefix,
-						"/" + t.bucket + "/" + t.path + "/" + strings.TrimPrefix(*pref.Prefix, f.path))
+				from := "/" + f.bucket + "/" + *pref.Prefix
+				to := "/" + t.bucket + "/" + t.path + "/" + strings.TrimPrefix(*pref.Prefix, f.path)
+				Log.Debug("Mv(%s, %s):", from, to)
+				err := s.Mv(from, to)
 				if err != nil {
+					Log.Error("Mv(%s, %s) failed:", from, to, err)
 					return false
 				}
 			}
 			return true
 		})
+	if err != nil {
+		Log.Error("ListObjectsV2Pages failed:", err)
+	}
 	return err
 }
 


### PR DESCRIPTION
Implementation of recursive move in S3 backend
- support folder rename (not bucket)
- uses paging S3 API so can rename move folders with more than 1000 files
- slow in my tests, probably because of sequential requests, but better than nothing
- if something fails, not moved files are kept in old folder
- silently overwrites target files