### PR TITLE
fix(history): call unlisten multiple times

### DIFF
--- a/client/components/decorator.js
+++ b/client/components/decorator.js
@@ -58,6 +58,7 @@ export function ErrorPage(WrappedComponent){
             this.unlisten = this.props.history.listen(() => {
                 this.setState({has_back_button: false});
                 this.unlisten();
+                this.unlisten = undefined;
             });
         }
 


### PR DESCRIPTION
this.unlisten will be called twice, it caused the problem: after you viewed a file, the back button of browser will not work.