### PR TITLE
Improve rename file form

### DIFF
--- a/client/pages/filespage/thing-existing.js
+++ b/client/pages/filespage/thing-existing.js
@@ -107,6 +107,7 @@ export class ExistingThing extends React.Component {
             is_renaming: false,
             preview: null
         };
+        this.filenameElement = React.createRef();
     }
 
     shouldComponentUpdate(nextProps, nextState){
@@ -143,6 +144,12 @@ export class ExistingThing extends React.Component {
                     this.setState({preview: url+"&thumbnail=true"});
                 });
             }
+        }
+    }
+
+    preventOpeningOnEnter(e){
+        if(e.keyCode === 13 && this.filenameElement.current) { // Enter
+            this.filenameElement.current.onRename(e);
         }
     }
 
@@ -249,14 +256,19 @@ export class ExistingThing extends React.Component {
 
         return connectDragSource(connectDropNativeFile(connectDropFile(
             <div className={"component_thing view-"+this.props.view+(this.props.selected === true ? " selected" : " not-selected")}>
-              <ToggleableLink onClick={this.onThingClick.bind(this)} to={fileLink + window.location.search} disabled={this.props.file.icon === "loading"}>
+              <ToggleableLink onClick={this.onThingClick.bind(this)} 
+                              to={fileLink + window.location.search} 
+                              disabled={this.props.file.icon === "loading"}
+                              onKeyDown={this.preventOpeningOnEnter.bind(this)}>
                 <Card ref="$card"className={this.state.hover} className={className}>
                   <Image preview={this.state.preview}
                          icon={this.props.file.icon || this.props.file.type}
                          view={this.props.view}
                          path={path.join(this.props.path, this.props.file.name)}
                          hide_extension={this.props.metadata.hide_extension} />
-                  <Filename filename={this.props.file.name}
+                  <Filename 
+                            ref={this.filenameElement}
+                            filename={this.props.file.name}
                             filesize={this.props.file.size}
                             filetype={this.props.file.type}
                             hide_extension={this.props.metadata.hide_extension}

--- a/client/pages/filespage/thing.scss
+++ b/client/pages/filespage/thing.scss
@@ -38,7 +38,9 @@
     }
     form{
         display: inline-block;
+        width: 100%;
         input{
+            width: 100%;
             font-size: 1em;
             border-width: 0px;
             padding: 0 2px 0 2px;

--- a/client/pages/filespage/thing.scss
+++ b/client/pages/filespage/thing.scss
@@ -38,7 +38,7 @@
     }
     form{
         display: inline-block;
-        width: 100%;
+        width: calc(100% - 130px);
         input{
             width: 100%;
             font-size: 1em;


### PR DESCRIPTION
When renaming a file, after pressing Enter, the file was successfully renamed but the it open itself (at least on Firefox) 
So now, when a link capture a keydown event with key Enter, then the onRename function is called on the filename component.

I also make a wider input because it was a bit strange to see the filename truncated during the edit.