### PR TITLE
fix notification width

### DIFF
--- a/client/components/notification.scss
+++ b/client/components/notification.scss
@@ -2,7 +2,7 @@
     position: fixed;
     bottom: 20px;
     left: 20px;
-    right: 0;
+    right: 70px;
     font-size: 0.95em;
     z-index: 1001;
 


### PR DESCRIPTION
Previously, the notification div was too wide and was hiding the "save" button in the text editor as shown in this image

![screen-bug-notification](https://user-images.githubusercontent.com/835068/133000133-0e7a2529-2be5-430a-9ad6-16a5c29d920d.png)

So I just moved the `right` limit to prevent this.