### PR TITLE
Issue & Fix : Enter key in custom css text area causes error

### DIFF
--- a/client/components/textarea.js
+++ b/client/components/textarea.js
@@ -20,7 +20,7 @@ export function Textarea({ ...props }) {
     const disabledEnter = (e) => {
         if(e.key === "Enter" && e.shiftKey === false){
             e.preventDefault();
-            const $form = getForm($el.current.ref);
+            const $form = getForm($el.current);
             if($form){
                 $form.dispatchEvent(new Event("submit", { cancelable: true }));
             }


### PR DESCRIPTION
## Details

When pressing enter key in custom.css text area (in Admin Console Settings 'admin/settings') , causes an error:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'parentElement')
```

## Steps to reproduce:

1. Login to admin console in filestash.
2. Click on "Settings" link on the left.
3. On the Settings page, select Custom Css text area.
4. Press enter key
5. Error appears. `Uncaught TypeError: Cannot read properties of undefined (reading 'parentElement')`

## Cause

In Line 23 in `client/components/textarea.js`, `$el.current.ref`, ref property is `undefined`.

## Proposed fix

Remove `ref` property reference, `$el.current.ref` to `$el.current`.

## Potential Impact

This fix could affect/break all text areas in filestash.
Hoping frontend tests will be able catch any undesirable impact from this fix.

## Note

From my limited manual testing of the custom css text area, this fix works.