### PR TITLE
Interpolate username in URL for DAV backends

### DIFF
--- a/server/plugin/plg_backend_dav/index.go
+++ b/server/plugin/plg_backend_dav/index.go
@@ -41,7 +41,7 @@ func (this Dav) Init(params map[string]string, app *App) (IBackend, error) {
 		return backend, nil
 	}
 	backend := Dav{
-		url:    params["url"],
+		url:    strings.ReplaceAll(params["url"], "%{username}", url.PathEscape(params["username"])),
 		which:  params["type"],
 		params: params,
 	}

--- a/server/plugin/plg_backend_webdav/index.go
+++ b/server/plugin/plg_backend_webdav/index.go
@@ -35,7 +35,7 @@ func (w WebDav) Init(params map[string]string, app *App) (IBackend, error) {
 	}
 	backend := WebDav{
 		params: &WebDavParams{
-			params["url"],
+			strings.ReplaceAll(params["url"], "%{username}", url.PathEscape(params["username"])),
 			params["username"],
 			params["password"],
 			params["path"],


### PR DESCRIPTION
In the URL parameters for DAV backends (WebDAV and CalDAV/CardDAV) the
`%{username}` string is interpolated to the URL encoded username. It
shouldn't conflict with legitimate URLS as `%{` is not a valid URL escape
sequence.

This is needed for some servers where the URL contains the username
such as Cyrus IMAP.