### PR TITLE
Add Dockerfile that builds the checked-out version of filestash

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,80 @@
+FROM debian:stable-slim AS build
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && \
+    apt-get install -y golang npm curl
+
+COPY . /src
+
+#WORKDIR /src/server/plugin/plg_image_light/deps
+#RUN ./create_libresize.sh
+#RUN ./create_libtranscode.sh
+
+WORKDIR /src
+RUN make build_init
+RUN make build_backend
+RUN npm install --include=dev --force
+RUN make build_frontend
+
+FROM debian:stable-slim
+MAINTAINER mickael@kerjean.me
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN mkdir -p /app
+COPY --from=build /src/filestash /app/filestash
+
+RUN apt-get update > /dev/null && \
+    #################
+    # Install
+    apt-get install -y libglib2.0-0 curl gnupg > /dev/null && \
+    echo $PUBLIC_KEY | gpg --import && \
+    cd /tmp/ && \
+    #curl --resolve downloads.filestash.app -s https://downloads.filestash.app/latest/filestash_`uname -s`-`uname -m`.tar.gpg | gpg --decrypt | tar xf - && \
+    #mv filestash /app/ && \
+    apt-get purge -y --auto-remove gnupg && \
+    #################
+    # Optional dependencies
+    apt-get install -y curl tor emacs-nox ffmpeg zip poppler-utils > /dev/null && \
+    # org-mode: html export
+    curl https://raw.githubusercontent.com/mickael-kerjean/filestash/master/server/.assets/emacs/htmlize.el > /usr/share/emacs/site-lisp/htmlize.el && \
+    # org-mode: markdown export
+    curl https://raw.githubusercontent.com/mickael-kerjean/filestash/master/server/.assets/emacs/ox-gfm.el > /usr/share/emacs/site-lisp/ox-gfm.el && \
+    # org-mode: pdf export (with a light latex distribution)
+    cd && apt-get install -y wget perl > /dev/null && \
+    export CTAN_REPO="http://mirror.las.iastate.edu/tex-archive/systems/texlive/tlnet" && \
+    curl -sL "https://yihui.name/gh/tinytex/tools/install-unx.sh" | sh && \
+    mv ~/.TinyTeX /usr/share/tinytex && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install wasy && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install ulem && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install marvosym && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install wasysym && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install xcolor && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install listings && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install parskip && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install float && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install wrapfig && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install sectsty && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install capt-of && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install epstopdf-pkg && \
+    /usr/share/tinytex/bin/x86_64-linux/tlmgr install cm-super && \
+    ln -s /usr/share/tinytex/bin/x86_64-linux/pdflatex /usr/local/bin/pdflatex && \
+    apt-get purge -y --auto-remove perl wget && \
+    # Cleanup
+    find /usr/share/ -name 'doc' | xargs rm -rf && \
+    find /usr/share/emacs -name '*.pbm' | xargs rm -f && \
+    find /usr/share/emacs -name '*.png' | xargs rm -f && \
+    find /usr/share/emacs -name '*.xpm' | xargs rm -f && \
+    #################
+    # Finalise the image
+    useradd filestash && \
+    chown -R filestash:filestash /app/ && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+USER filestash
+RUN timeout 1 /app/filestash | grep -q start
+
+EXPOSE 8334
+VOLUME ["/app/data/state/"]
+WORKDIR "/app"
+CMD ["/app/filestash"]


### PR DESCRIPTION
I noticed there was no way to build a Docker image from a checked-out version of the code. As I am working on the code and need to test the changes I make, I thought it would be a good idea to have a Dockerfile that can do that.

I took the existing Dockerfile, but instead of downloading the release from the Internet, I build it in a multistage Dockerfile.

This is still work in progress as I haven't fully tested it yet.