### PR TITLE
Fix s3 rename again

### DIFF
--- a/server/plugin/plg_backend_s3/index.go
+++ b/server/plugin/plg_backend_s3/index.go
@@ -486,7 +486,9 @@ func (s S3Backend) urlEncodedPath(path string) string {
 
 	var pathElements []string
 	for _, x := range sp {
-		pathElements = append(pathElements, url.QueryEscape(x))
+		// Compatible with RFC 3986.
+		endoded := strings.Replace(url.QueryEscape(x), "+", "%20", -1)
+		pathElements = append(pathElements, endoded)
 	}
 
 	encodedPath := strings.Join(pathElements, "/")


### PR DESCRIPTION

Commit 1f447dc7d0 fixed an error cause by a wrong url encoding of the space character but reintroduced the bug occurring with special characters (you can try to rename a file "testé.txt" to "test.txt" to see the error).

Now I understand why this occurred (it took me quiet some time!)

Due to special characters, we must url-encode names when moving files in S3, but, the standard QueryEscape from go encodes a space with a "+" character, which does not respect the RFC. The S3 api expects "%20"

There is no other standard function that behaves as expected as it is show in this snippet: https://go.dev/play/p/pOfrn-Wsq5

So the best way was to use QueryEscape  but replace "+" by "%20"

Now everything works!
