### PR TITLE
fix (sftp_backend): wait until all requests are finished before closing

### DIFF
--- a/server/plugin/plg_backend_sftp/index.go
+++ b/server/plugin/plg_backend_sftp/index.go
@@ -1,14 +1,16 @@
 package plg_backend_sftp
 
 import (
-	. "github.com/mickael-kerjean/filestash/server/common"
-	"github.com/pkg/sftp"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"net"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+
+	. "github.com/mickael-kerjean/filestash/server/common"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 )
 
 var SftpCache AppCache
@@ -16,6 +18,7 @@ var SftpCache AppCache
 type Sftp struct {
 	SSHClient  *ssh.Client
 	SFTPClient *sftp.Client
+	wg         *sync.WaitGroup
 }
 
 func init() {
@@ -24,6 +27,11 @@ func init() {
 	SftpCache = NewAppCache()
 	SftpCache.OnEvict(func(key string, value interface{}) {
 		c := value.(*Sftp)
+		if c.wg != nil {
+			c.wg.Wait()
+		} else {
+			Log.Warning("plg_backend_sftp::wg is nil on close")
+		}
 		if c != nil {
 			c.Close()
 		}
@@ -51,6 +59,15 @@ func (s Sftp) Init(params map[string]string, app *App) (IBackend, error) {
 	c := SftpCache.Get(params)
 	if c != nil {
 		d := c.(*Sftp)
+		if d.wg != nil {
+			d.wg.Add(1)
+			go func() {
+				<-app.Context.Done()
+				d.wg.Done()
+			}()
+		} else {
+			Log.Warning("plg_backend_sftp::wg is nil on get")
+		}
 		return d, nil
 	}
 
@@ -146,6 +163,12 @@ func (s Sftp) Init(params map[string]string, app *App) (IBackend, error) {
 		return &s, err
 	}
 	s.SFTPClient = session
+	s.wg = new(sync.WaitGroup)
+	s.wg.Add(1)
+	go func() {
+		<-app.Context.Done()
+		s.wg.Done()
+	}()
 	SftpCache.Set(params, &s)
 	return &s, nil
 }


### PR DESCRIPTION
I found that my downloads always failed with the error `failed to send packet: EOF` in a range between a few minutes up to nearly ten minutes. I then found out that the ssh  connection is closed periodically every ten minutes on cache cleanup: https://github.com/mickael-kerjean/filestash/blob/d265d5b5e07030a3222a3fabd02da2dad9c8cca6/server/common/cache.go#L50.
To fix this issue, I added a waitgroup to the backend, that it is only closed once the request is finished 