### PR TITLE
#516: add Docker security option to prevent awkward Office crash

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,5 +15,8 @@ services:
 
   onlyoffice:
     container_name: filestash_oods
-    image: onlyoffice/documentserver:6.4.2
+    image: onlyoffice/documentserver
     restart: always
+    security_opt:
+      - seccomp:unconfined
+


### PR DESCRIPTION
Docker has introduced a new kind of crash (that may or may not be related to the combination of host and guest kernel versions). Among other things, it broke the OnlyOffice container:

    $ docker-compose logs
    ...
    filestash_oods | /var/www/onlyoffice/documentserver/npm/json[24]: ../src/node_platform.cc:61:std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start(): Assertion `(0) == (uv_thread_create(t.get(), start_thread, this))' failed.
    filestash_oods |  1: 0x8e08f0 node::Abort() [/var/www/onlyoffice/documentserver/npm/json]
    filestash_oods |  2: 0x8e096c  [/var/www/onlyoffice/documentserver/npm/json]
    filestash_oods |  3: 0x94c4f7 node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/var/www/onlyoffice/documentserver/npm/json]
    filestash_oods |  4: 0x94c607 node::NodePlatform::NodePlatform(int, v8::TracingController*) [/var/www/onlyoffice/documentserver/npm/json]
    filestash_oods |  5: 0x8bee61 node::InitializeOncePerProcess(int, char**) [/var/www/onlyoffice/documentserver/npm/json]
    filestash_oods |  6: 0x8bf19c node::Start(int, char**) [/var/www/onlyoffice/documentserver/npm/json]
    filestash_oods |  7: 0x7f06743e2d90  [/lib/x86_64-linux-gnu/libc.so.6]
    filestash_oods |  8: 0x7f06743e2e40 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
    filestash_oods |  9: 0x842a71  [/var/www/onlyoffice/documentserver/npm/json]
    ...
    filestash_oods | /app/ds/run-document-server.sh: line 215: -3: substring expression < 0
    filestash_oods | nc: port number invalid:
    filestash_oods | Waiting for connection to the  host on port

This PR adds a setting to the docker-compose file to prevent this fun experience.