### PR TITLE
fix(locales): hostname pt language to "nome de host" instead "nome de anfitrião"

### DIFF
--- a/client/locales/pt.json
+++ b/client/locales/pt.json
@@ -43,7 +43,7 @@
     "ERROR": "erro",
     "FREQUENTLY_ACCESS_FOLDERS_WILL_BE_SHOWN_HERE": "As pastas de acesso frequente serão mostradas aqui",
     "HOST_KEY": "chave do host",
-    "HOSTNAME*": "nome de anfitrião*",
+    "HOSTNAME*": "nome de host*",
     "INCORRECT_PASSWORD": "senha incorreta",
     "INFO": "informação",
     "INTERNAL_ERROR": "Erro interno",


### PR DESCRIPTION
The current host name with key **HOSTNAME*** is not translated in the best way (located in host input).
The "host" term should not be directly translated, should be used "host" name instead "anfitrião".

The recomended way:

![image](https://user-images.githubusercontent.com/27220715/200403361-aaa84db7-5f0b-407a-8acd-6c394a8ef2a1.png)

Non recomended way:

![image](https://user-images.githubusercontent.com/27220715/200412274-c14267e8-57a3-4547-8641-93d43538f7fe.png)

