### PR TITLE
add inlang to make contribution translations easier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@ For anything else than a typo or a bug fix, please raise an issue to discuss you
 
 As the copyright owner, you agree to license your contributions under an irrevocable MIT license.
 
+## Translations
+
+Contribute translations via https://inlang.com/editor/github.com/mickael-kerjean/filestash
 
 ### Building from source
 

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,60 @@
+// https://inlang.com/documentation
+
+export async function defineConfig(env) {
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@1/dist/index.js"
+  );
+
+  const pluginConfig = {
+    pathPattern: "./client/locales/{language}.json",
+  };
+
+  return {
+    referenceLanguage: "en",
+    languages: [
+      "az",
+      "be",
+      "bg",
+      "ca",
+      "cs",
+      "da",
+      "de",
+      "el",
+      "es",
+      "et",
+      "fi",
+      "fr",
+      "gl",
+      "hr",
+      "hu",
+      "id",
+      "is",
+      "it",
+      "ja",
+      "ka",
+      "ko",
+      "lt",
+      "lv",
+      "mn",
+      "nb",
+      "nl",
+      "pl",
+      "pt",
+      "ro",
+      "ru",
+      "sk",
+      "sl",
+      "sr",
+      "sv",
+      "th",
+      "uk",
+      "vi",
+      "zh",
+      "zh_tw"
+    ],
+    readResources: (args) =>
+      plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) =>
+      plugin.writeResources({ ...args, ...env, pluginConfig }),
+  };
+}


### PR DESCRIPTION
This pull request adds the possibility for contributors to add translations via a UI. Try the following link (of the forked repo) https://inlang.com/editor/github.com/samuelstroschein/filestash.

Note that no reference language resource (`en.json`) exists in this repository. In theory, inlang requires an English resource file to lint whether translations are missing, broken, or need to be updated. Contributing translations should be easier but inlang might stop working when linting and validation of the config is implemented, see https://github.com/inlang/inlang/issues/309.  