### PR TITLE
feature (plg_backend_s3): add param for forcePathStyle

### DIFF
--- a/server/plugin/plg_backend_s3/index.go
+++ b/server/plugin/plg_backend_s3/index.go
@@ -63,7 +63,7 @@ func (s S3Backend) Init(params map[string]string, app *App) (IBackend, error) {
 	config := &aws.Config{
 		Credentials:                   credentials.NewChainCredentials(creds),
 		CredentialsChainVerboseErrors: aws.Bool(true),
-		S3ForcePathStyle:              aws.Bool(true),
+		S3ForcePathStyle:              aws.Bool(params["url_style"] == "path-style"),
 		Region:                        aws.String(params["region"]),
 	}
 	if params["endpoint"] != "" {
@@ -101,7 +101,7 @@ func (s S3Backend) LoginForm() Form {
 				Name:        "advanced",
 				Type:        "enable",
 				Placeholder: "Advanced",
-				Target:      []string{"s3_path", "s3_session_token", "s3_encryption_key", "s3_region", "s3_endpoint"},
+				Target:      []string{"s3_path", "s3_session_token", "s3_encryption_key", "s3_region", "s3_endpoint", "s3_url_style"},
 			},
 			FormElement{
 				Id:          "s3_session_token",
@@ -132,6 +132,15 @@ func (s S3Backend) LoginForm() Form {
 				Name:        "endpoint",
 				Type:        "text",
 				Placeholder: "Endpoint",
+			},
+			FormElement{
+				Id:          "s3_url_style",
+				Name:        "url_style",
+				Type:        "select",
+				Default:     "path-style",
+				Opts:        []string{"path-style", "virtual-hosted–style"},
+				Description: "Amazon S3 supports both virtual-hosted–style and path-style URL access in all AWS Regions. Default: \"path-style\"",
+				Placeholder: "S3 URL Style",
 			},
 		},
 	}


### PR DESCRIPTION
Sorroy, i'm not good at webpage. i don't know how to add Placeholder for Select, today seems something ugly..
![image](https://user-images.githubusercontent.com/6848593/229849139-b66507b4-cef9-4885-afb6-47ea1d50133f.png)


> Amazon S3 supports both virtual-hosted–style and path-style URL access in all AWS Regions.

close: #357 