### PR TITLE
fix: show loading spinner on audio player page

### DIFF
--- a/client/pages/viewerpage/audioplayer.js
+++ b/client/pages/viewerpage/audioplayer.js
@@ -7,7 +7,7 @@ import "./audioplayer.scss";
 
 export function AudioPlayer({ filename, data }) {
     const [isPlaying, setIsPlaying] = useState(false);
-    const [isLoading, setIsLoading] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
     const wavesurfer = useRef(null);
 


### PR DESCRIPTION
Shows a loading spinner for audio file pages.
See this [issue](https://github.com/mickael-kerjean/filestash/issues/592) for details.

Closes #592