### PR TITLE
fix: VerifyApiKey config getter and conditions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ git clone https://github.com/mickael-kerjean/filestash
 cd filestash
 
 # Install dependencies
-npm install # frontend dependencies
+npm install --legacy-peer-deps # frontend dependencies
 make build_init # install the required static libraries
 mkdir -p ./dist/data/state/
 cp -R config ./dist/data/state/

--- a/server/common/api.go
+++ b/server/common/api.go
@@ -8,20 +8,20 @@ import (
 
 func VerifyApiKey(api_key string) (host string, err error) {
 	isApiEnabled := Config.Get("features.api.enable").Bool()
-	apiKey := Config.Get("feature.api.api_key").String()
+	allowedApiKeys := Config.Get("features.api.api_key").String()
 
 	if isApiEnabled == false {
 		return "", NewError("Api is not enabled", 503)
-	} else if apiKey == os.Getenv("API_KEY") {
+	} else if api_key == os.Getenv("API_KEY") {
 		return "*", nil
 	}
-	lines := strings.Split(apiKey, "\n")
+	lines := strings.Split(allowedApiKeys, "\n")
 	for _, line := range lines {
 		line = regexp.MustCompile(` #.*`).ReplaceAllString(line, "") // remove comment
 		chunks := strings.SplitN(line, " ", 2)
 		if len(chunks) == 0 {
 			continue
-		} else if chunks[0] != apiKey {
+		} else if chunks[0] != api_key {
 			continue
 		}
 		if len(chunks) == 1 {


### PR DESCRIPTION
I've been experimenting with Filestash, particularly its API, and encountered a weird issue: any API key I provided was being accepted.

I suspect the `VerifyApiKey()` function has been broken for some time:

1. The `api_key` parameter wasn't utilized within the function. All conditions and comparisons were conducted against the `apiKey`, sourced from the config.
2. There's a typo in the config path when retrieving the `apiKey` config value. Consequently, the `apiKey` value always returns as an empty string. This also means any API key will be accepted if the `API_KEY` environment variable isn't defined.

Other things (feel free to change):
- I renamed `apiKey` to `allowedApiKeys` for clarity
- Added the --legacy-peer-deps flag in the contribution doc, that flag seems to be required (and it's also present in the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/Dockerfile#L12))