### PR TITLE
feat: pgl_backend_s3: add option for no_verify_ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ cover.*
 www
 .gitignore
 
+.idea
 
 # frontend
 public/**/*.test.js

--- a/client/components/formbuilder.js
+++ b/client/components/formbuilder.js
@@ -265,7 +265,8 @@ const FormElement = ({
     case "boolean":
         $input = (
             <Input onChange={(e) => props.onChange(e.target.checked)} {...id} name={struct.label}
-                type="checkbox" checked={struct.value === null ? !!struct.default : struct.value} />
+                type="checkbox" checked={struct.value === null ? !!struct.default : struct.value}
+                   placeholder={ t(struct.placeholder) }/>
         );
         break;
     case "select":

--- a/client/components/input.js
+++ b/client/components/input.js
@@ -12,17 +12,22 @@ export class Input extends React.Component {
         switch(this.props.type) {
         case "checkbox":
             return (
-                <div
-                    className="component_checkbox"
-                    onMouseDown={this.props.onMouseDown && this.props.onMouseDown.bind(this)}
-                    onMouseUp={this.props.onMouseUp && this.props.onMouseUp.bind(this)}>
-                    <input
-                        type="checkbox"
-                        {...this.props}
-                        onChange={this.props.onChange || nop}
-                        ref={(comp) => this.ref = comp } />
-                    <span className="indicator"></span>
-                </div>
+                <React.Fragment>
+                    <div
+                        className="component_checkbox"
+                        onMouseDown={this.props.onMouseDown && this.props.onMouseDown.bind(this)}
+                        onMouseUp={this.props.onMouseUp && this.props.onMouseUp.bind(this)}>
+                        <input
+                            type="checkbox"
+                            {...this.props}
+                            onChange={this.props.onChange || nop}
+                            ref={(comp) => this.ref = comp } />
+                        <span className="indicator"></span>
+                    </div>
+                    <span style={{"color": "rgba(0, 0, 0, 0.4)"}}>
+                        {this.props.placeholder}
+                    </span>
+                </React.Fragment>
             );
         default:
             return (


### PR DESCRIPTION
As a User I want to be able to ignore SSL Verification (in case the authority is unknown f.e.) so that I can still connect without getting x509 certificate errors.

This PR adds a checkbox where the user can check this option:

![image](https://github.com/mickael-kerjean/filestash/assets/10099328/0c3276a5-94ae-4edd-b062-0df2651456bf)

This PR also adds the option to use boolean checkboxes **with labels** via the Formbuilder.

I did not add any translations as the other fields didn't have any as well. I also am missing a contribution Guide