### PR TITLE
Choose tinytex's tlmgr for the platform that docker builds on

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,20 +42,21 @@ RUN apt-get update > /dev/null && \
     export CTAN_REPO="http://mirror.las.iastate.edu/tex-archive/systems/texlive/tlnet" && \
     curl -sL "https://yihui.name/gh/tinytex/tools/install-unx.sh" | sh && \
     mv ~/.TinyTeX /usr/share/tinytex && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install wasy && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install ulem && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install marvosym && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install wasysym && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install xcolor && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install listings && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install parskip && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install float && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install wrapfig && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install sectsty && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install capt-of && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install epstopdf-pkg && \
-    /usr/share/tinytex/bin/x86_64-linux/tlmgr install cm-super && \
-    ln -s /usr/share/tinytex/bin/x86_64-linux/pdflatex /usr/local/bin/pdflatex && \
+    FS_ARCH=$(uname -m) && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install wasy && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install ulem && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install marvosym && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install wasysym && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install xcolor && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install listings && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install parskip && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install float && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install wrapfig && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install sectsty && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install capt-of && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install epstopdf-pkg && \
+    /usr/share/tinytex/bin/${FS_ARCH}-linux/tlmgr install cm-super && \
+    ln -s /usr/share/tinytex/bin/${FS_ARCH}-linux/pdflatex /usr/local/bin/pdflatex && \
     apt-get purge -y --auto-remove perl wget && \
     # Cleanup
     find /usr/share/ -name 'doc' | xargs rm -rf && \


### PR DESCRIPTION
I wasn't able to build on the aarch64 platform, so I looked at the Docker files and found that I could change the tlmgr to a platform-specific directory name using uname -m to select the binaries.

The CI currently in use does not appear to be written to be multiplatform using buildx, but this slight modification should allow us to build on aarch64 temporarily.

Check out the submitted commit, and if it's good, confirm it.

I have verified that it builds fine Tested on WSL in Windows 11 and Arm instance of Oracle Cloud.