### PR TITLE
Add share button to submenu

### DIFF
--- a/client/pages/filespage/submenu.js
+++ b/client/pages/filespage/submenu.js
@@ -8,6 +8,7 @@ import {
 } from "../../components/";
 import { debounce, alert, confirm, prompt, notify } from "../../helpers/";
 import { Files } from "../../model/";
+import { ShareComponent } from "./share";
 import { t } from "../../locales/";
 import "./submenu.scss";
 class SubmenuComponent extends React.Component {
@@ -125,6 +126,13 @@ class SubmenuComponent extends React.Component {
         }
     }
 
+    onShareRequest(filename) {
+        alert.now(
+            <ShareComponent path={this.props.file.path} type={this.props.file.type} />,
+            (ok) => {},
+        );
+    }
+
     render() {
         return (
             <div className={"component_submenu" + (this.props.selected.length > 0 || this.state.search_input_visible ? " sticky" : "")}>
@@ -143,6 +151,13 @@ class SubmenuComponent extends React.Component {
                             onClick={this.onNew.bind(this, "directory")}
                             type="inline">
                             { window.innerWidth < 410 && t("New Folder").length > 10 ? t("New Folder", null, "NEW_FOLDER::SHORT") : t("New Folder") }
+                        </NgIf>
+                        <NgIf
+                            className="button-share"
+                            cond={this.props.metadata.can_share !== false && window.CONFIG.enable_share === true && this.props.selected.length === 0}
+                            onClick={this.onShareRequest.bind(this)}
+                            type="inline">
+                            { t("Share") }
                         </NgIf>
                         <NgIf
                             className="button-download"


### PR DESCRIPTION
Unless I'm missing something, there's no way to share the currently selected folder. I find this very inconvenient, especially that you can't share the toplevel folder without editing the database to point an existing link/insert a new link pointing to it.

No clue if this works, since when trying to make a test build, `npm run build` crashes for some reason:

```sh
% make build_frontend
make: *** [Makefile:10: build_frontend] Illegal instruction (core dumped)

% npm run build

> filestash@0.0.0 build
> webpack

[1]    206949 illegal hardware instruction (core dumped)  npm run build
```

I have AVX512 disabled to fix an issue on my system so maybe that's it.

I know you prefer IRC to discuss changes, but I was curious and it seemed easy enough. Plus I'm not an IRC guy.