### PR TITLE
feature (Groovy): codemirror highlighting support

### DIFF
--- a/client/pages/viewerpage/editor.js
+++ b/client/pages/viewerpage/editor.js
@@ -211,7 +211,8 @@ export class EditorClass extends React.Component {
         else if (ext === "sparql") mode = "sparql";
         else if (ext === "properties") mode = "properties";
         else if (ext === "c" || ext === "cpp" || ext === "java" || ext === "h") mode = "clike";
-        else mode = "text";
+	else if (ext === "groovy" || ext === "gvy" || ext === "gy" || ext === "gsh") mode = "groovy";
+	else mode = "text";
 
         return import(/* webpackChunkName: "editor" */"./editor/"+mode)
             .catch(() => import("./editor/text"))

--- a/client/pages/viewerpage/editor.js
+++ b/client/pages/viewerpage/editor.js
@@ -211,8 +211,8 @@ export class EditorClass extends React.Component {
         else if (ext === "sparql") mode = "sparql";
         else if (ext === "properties") mode = "properties";
         else if (ext === "c" || ext === "cpp" || ext === "java" || ext === "h") mode = "clike";
-	else if (ext === "groovy" || ext === "gvy" || ext === "gy" || ext === "gsh") mode = "groovy";
-	else mode = "text";
+        else if (ext === "groovy" || ext === "gvy" || ext === "gy" || ext === "gsh") mode = "groovy";
+        else mode = "text";
 
         return import(/* webpackChunkName: "editor" */"./editor/"+mode)
             .catch(() => import("./editor/text"))

--- a/client/pages/viewerpage/editor/groovy.js
+++ b/client/pages/viewerpage/editor/groovy.js
@@ -1,0 +1,3 @@
+import "codemirror/mode/groovy/groovy";
+CodeMirror.__mode = "groovy";
+export default CodeMirror;

--- a/public/assets/pages/viewerpage/application_editor.js
+++ b/public/assets/pages/viewerpage/application_editor.js
@@ -266,6 +266,7 @@ function loadMode(ext) {
     else if (ext === "properties") mode = "properties";
     else if (ext === "c" || ext === "cpp" || ext === "h") mode = "clike";
     else if (ext === "java") mode = "java";
+    else if (ext === "groovy" || ext === "gvy" || ext === "gy" || ext === "gsh") mode = "groovy";
 
     return before.then(() => loadJS(import.meta.url, `./application_editor/${mode}.js`, { type: "module" }))
         .catch(() => loadJS(import.meta.url, "./application_editor/text.js", { type: "module" }))

--- a/public/assets/pages/viewerpage/application_editor/groovy.js
+++ b/public/assets/pages/viewerpage/application_editor/groovy.js
@@ -1,0 +1,3 @@
+import "../../../lib/vendor/codemirror/mode/groovy/groovy.js";
+window.CodeMirror.__mode = "groovy";
+export default window.CodeMirror;


### PR DESCRIPTION
Edit `loadMode` to recognize Groovy's file extensions and add an editor mode to load Codemirror's Groovy syntax highlighting