### PR TITLE
Restore file download UI when OnlyOffice plugin is disabled

### DIFF
--- a/server/common/plugin.go
+++ b/server/common/plugin.go
@@ -194,13 +194,24 @@ func (this Get) FrontendOverrides() []string {
 	return overrides
 }
 
-var xdg_open []string
+var xdg_open []func() string
 
 func (this Register) XDGOpen(jsString string) {
-	xdg_open = append(xdg_open, jsString)
+	xdg_open = append(xdg_open, func() string {
+		return jsString
+	})
 }
+
+func (this Register) XDGOpenFunc(fn func() string) {
+	xdg_open = append(xdg_open, fn)
+}
+
 func (this Get) XDGOpen() []string {
-	return xdg_open
+	var s []string
+	for i := 0; i < len(xdg_open); i++ {
+		s = append(s, xdg_open[i]())
+	}
+	return s
 }
 
 var cssOverride []func() string

--- a/server/plugin/plg_editor_onlyoffice/index.go
+++ b/server/plugin/plg_editor_onlyoffice/index.go
@@ -108,14 +108,19 @@ func init() {
 		).Methods("GET")
 		return nil
 	})
-	Hooks.Register.XDGOpen(`
+	Hooks.Register.XDGOpenFunc(func() string {
+		if plugin_enable() == false {
+			return ""
+		}
+		return `
         if(mime === "application/word" || mime === "application/msword" ||
            mime === "application/vnd.oasis.opendocument.text" || mime === "application/vnd.oasis.opendocument.spreadsheet" ||
            mime === "application/excel" || mime === "application/vnd.ms-excel" || mime === "application/powerpoint" ||
            mime === "application/vnd.ms-powerpoint" || mime === "application/vnd.oasis.opendocument.presentation" ) {
               return ["appframe", {"endpoint": "/api/onlyoffice/iframe"}];
            }
-   `)
+   `
+	})
 }
 
 func StaticHandler(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Previously, the OnlyOffice plugin statically registered mime types with `Hooks.Register.XDGOpen` on initialization; however, this meant that if you disabled the plugin, those mime types would still remain associated with the plugin. In that case, any office document would return a blank page, since it would still attempt to open with the disabled OnlyOffice plugin handlers.

This change adds a new `Hooks.Register.XDGOpenFunc` hook, so that code in `xdg-open.js` can be evaluated dynamically. With it, mime type overrides can be returned only when the OnlyOffice plugin is enabled. 

While the private API for `xdg_open` now accepts an array of functions returning a string (similar to the CSS hook), the public API for `Hooks.Register.XDGOpen` and  `Hooks.Get.XDGOpen` remains unchanged, so this shouldn't break any 3rd party plugins using it.

Fixes issue #717.