### PR TITLE
improvement (IAuthentication): extension of IAuthentication

### DIFF
--- a/server/common/types.go
+++ b/server/common/types.go
@@ -23,7 +23,7 @@ type IBackend interface {
 type IAuthentication interface {
 	Setup() Form
 	EntryPoint(idpParams map[string]string, req *http.Request, res http.ResponseWriter) error
-	Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error)
+	Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error)
 }
 
 type IAuthorisation interface {

--- a/server/common/types.go
+++ b/server/common/types.go
@@ -23,7 +23,7 @@ type IBackend interface {
 type IAuthentication interface {
 	Setup() Form
 	EntryPoint(idpParams map[string]string, req *http.Request, res http.ResponseWriter) error
-	Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error)
+	Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error)
 }
 
 type IAuthorisation interface {

--- a/server/common/utils.go
+++ b/server/common/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"strconv"
 )
 
@@ -90,4 +91,29 @@ func CookieName(idx int) string {
 		return COOKIE_NAME_AUTH
 	}
 	return COOKIE_NAME_AUTH + strconv.Itoa(idx)
+}
+
+func FormData(req *http.Request) (map[string]string, error) {
+	_get := req.URL.Query()
+	formData := map[string]string{}
+	switch req.Method {
+	case "GET":
+		for key, element := range _get {
+			if len(element) == 0 {
+				continue
+			}
+			formData[key] = element[0]
+		}
+	case "POST":
+		if err := req.ParseForm(); err != nil {
+			return nil, NewError(err.Error(), 400)
+		}
+		for key, values := range req.Form {
+			if len(values) == 0 {
+				continue
+			}
+			formData[key] = values[0]
+		}
+	}
+	return formData, nil
 }

--- a/server/ctrl/session.go
+++ b/server/ctrl/session.go
@@ -246,31 +246,6 @@ func SessionAuthMiddleware(ctx *App, res http.ResponseWriter, req *http.Request)
 		)
 		return
 	}
-	formData := map[string]string{}
-	switch req.Method {
-	case "GET":
-		for key, element := range _get {
-			if len(element) == 0 {
-				continue
-			}
-			formData[key] = element[0]
-		}
-	case "POST":
-		if err := req.ParseForm(); err != nil {
-			http.Redirect(
-				res, req,
-				"/?error=Not%20Valid&trace=parsing body - "+err.Error(),
-				http.StatusTemporaryRedirect,
-			)
-			return
-		}
-		for key, values := range req.Form {
-			if len(values) == 0 {
-				continue
-			}
-			formData[key] = values[0]
-		}
-	}
 	idpParams := map[string]string{}
 	if err := json.Unmarshal(
 		[]byte(Config.Get("middleware.identity_provider.params").String()),
@@ -308,7 +283,7 @@ func SessionAuthMiddleware(ctx *App, res http.ResponseWriter, req *http.Request)
 	// Step2: End of the authentication process. Could come from:
 	// - target of a html form. eg: ldap, mysql, ...
 	// - identity provider redirection uri. eg: oauth2, openid, ...
-	templateBind, err := plugin.Callback(formData, idpParams, req, res)
+	templateBind, err := plugin.Callback(idpParams, req, res)
 	if err == ErrAuthenticationFailed {
 		http.Redirect(
 			res, req,

--- a/server/ctrl/session.go
+++ b/server/ctrl/session.go
@@ -308,7 +308,7 @@ func SessionAuthMiddleware(ctx *App, res http.ResponseWriter, req *http.Request)
 	// Step2: End of the authentication process. Could come from:
 	// - target of a html form. eg: ldap, mysql, ...
 	// - identity provider redirection uri. eg: oauth2, openid, ...
-	templateBind, err := plugin.Callback(formData, idpParams, res)
+	templateBind, err := plugin.Callback(formData, idpParams, req, res)
 	if err == ErrAuthenticationFailed {
 		http.Redirect(
 			res, req,

--- a/server/plugin/plg_authenticate_admin/index.go
+++ b/server/plugin/plg_authenticate_admin/index.go
@@ -64,7 +64,7 @@ func (this Admin) EntryPoint(idpParams map[string]string, req *http.Request, res
 	return nil
 }
 
-func (this Admin) Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error) {
+func (this Admin) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	if err := bcrypt.CompareHashAndPassword(
 		[]byte(Config.Get("auth.admin").String()),
 		[]byte(formData["password"]),

--- a/server/plugin/plg_authenticate_admin/index.go
+++ b/server/plugin/plg_authenticate_admin/index.go
@@ -64,7 +64,12 @@ func (this Admin) EntryPoint(idpParams map[string]string, req *http.Request, res
 	return nil
 }
 
-func (this Admin) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+func (this Admin) Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+	formData, err := FormData(req)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := bcrypt.CompareHashAndPassword(
 		[]byte(Config.Get("auth.admin").String()),
 		[]byte(formData["password"]),

--- a/server/plugin/plg_authenticate_htpasswd/index.go
+++ b/server/plugin/plg_authenticate_htpasswd/index.go
@@ -82,11 +82,17 @@ func (this Htpasswd) EntryPoint(idpParams map[string]string, req *http.Request, 
 	return nil
 }
 
-func (this Htpasswd) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+func (this Htpasswd) Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	if idpParams["users"] == "" {
 		Log.Error("plg_authenticate_htpasswd::callback there is no user configured")
 		return nil, NewError("You haven't configured any users", 500)
 	}
+
+	formData, err := FormData(req)
+	if err != nil {
+		return nil, err
+	}
+
 	lines := strings.Split(idpParams["users"], "\n")
 	for n, line := range lines {
 		pair := strings.SplitN(line, ":", 2)

--- a/server/plugin/plg_authenticate_htpasswd/index.go
+++ b/server/plugin/plg_authenticate_htpasswd/index.go
@@ -82,7 +82,7 @@ func (this Htpasswd) EntryPoint(idpParams map[string]string, req *http.Request, 
 	return nil
 }
 
-func (this Htpasswd) Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error) {
+func (this Htpasswd) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	if idpParams["users"] == "" {
 		Log.Error("plg_authenticate_htpasswd::callback there is no user configured")
 		return nil, NewError("You haven't configured any users", 500)

--- a/server/plugin/plg_authenticate_ldap/index.go
+++ b/server/plugin/plg_authenticate_ldap/index.go
@@ -67,6 +67,6 @@ func (this Ldap) EntryPoint(idpParams map[string]string, req *http.Request, res 
 	return nil
 }
 
-func (this Ldap) Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error) {
+func (this Ldap) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return nil, ErrNotImplemented
 }

--- a/server/plugin/plg_authenticate_ldap/index.go
+++ b/server/plugin/plg_authenticate_ldap/index.go
@@ -67,6 +67,6 @@ func (this Ldap) EntryPoint(idpParams map[string]string, req *http.Request, res 
 	return nil
 }
 
-func (this Ldap) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+func (this Ldap) Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return nil, ErrNotImplemented
 }

--- a/server/plugin/plg_authenticate_openid/index.go
+++ b/server/plugin/plg_authenticate_openid/index.go
@@ -53,6 +53,6 @@ func (this OpenID) EntryPoint(idpParams map[string]string, req *http.Request, re
 	return nil
 }
 
-func (this OpenID) Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error) {
+func (this OpenID) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return nil, ErrNotImplemented
 }

--- a/server/plugin/plg_authenticate_openid/index.go
+++ b/server/plugin/plg_authenticate_openid/index.go
@@ -53,6 +53,6 @@ func (this OpenID) EntryPoint(idpParams map[string]string, req *http.Request, re
 	return nil
 }
 
-func (this OpenID) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+func (this OpenID) Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return nil, ErrNotImplemented
 }

--- a/server/plugin/plg_authenticate_passthrough/index.go
+++ b/server/plugin/plg_authenticate_passthrough/index.go
@@ -68,7 +68,12 @@ func (this Admin) EntryPoint(idpParams map[string]string, req *http.Request, res
 	return nil
 }
 
-func (this Admin) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+func (this Admin) Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+	formData, err := FormData(req)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[string]string{
 		"user":     formData["user"],
 		"password": formData["password"],

--- a/server/plugin/plg_authenticate_passthrough/index.go
+++ b/server/plugin/plg_authenticate_passthrough/index.go
@@ -68,7 +68,7 @@ func (this Admin) EntryPoint(idpParams map[string]string, req *http.Request, res
 	return nil
 }
 
-func (this Admin) Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error) {
+func (this Admin) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return map[string]string{
 		"user":     formData["user"],
 		"password": formData["password"],

--- a/server/plugin/plg_authenticate_saml/index.go
+++ b/server/plugin/plg_authenticate_saml/index.go
@@ -49,6 +49,6 @@ func (this Saml) EntryPoint(idpParams map[string]string, req *http.Request, res 
 	return nil
 }
 
-func (this Saml) Callback(formData map[string]string, idpParams map[string]string, res http.ResponseWriter) (map[string]string, error) {
+func (this Saml) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return nil, ErrNotImplemented
 }

--- a/server/plugin/plg_authenticate_saml/index.go
+++ b/server/plugin/plg_authenticate_saml/index.go
@@ -49,6 +49,6 @@ func (this Saml) EntryPoint(idpParams map[string]string, req *http.Request, res 
 	return nil
 }
 
-func (this Saml) Callback(formData map[string]string, idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
+func (this Saml) Callback(idpParams map[string]string, req *http.Request, res http.ResponseWriter) (map[string]string, error) {
 	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
original description at https://github.com/mickael-kerjean/filestash/pull/702

> This PR extends the existing `IAuthentication` interface's `Callback()` function to include the `*http.Request` parameter. 
> 
> This enhancement allows plugins implementing this interface to access the HTTP request directly, and thereby enabling them to retrieve additional information, such as cookies, via `req.Cookie("my-cookie")`. Additionally, it allows for request parsing to be handled by the plugin itself if desired.
> Processing cookies during the `Callback()` can be highly beneficial for various login flows.
> 
> The PR is structured into two commits:
> 
> 1. **first commit**
>    - extends the interface and updates existing plugins accordingly
> 
> Since this addition only involves adding a new parameter to the function signature, which is currently ignored in all existing plugins, it can be considered a minor change with essentially no impact on existing authentication plugins, although their signatures have to be updated, as I have done in this PR.
> 
> 2. **second commit:**
>    - removes `formData` from the function signature to avoid redundancy in passing both the request and the parsed body
>    - moves the existing parsing code to a utility function, which can be called from within the plugin, ensuring full compatibility with existing plugins
> 
> This introduces a minor change in error handling: Parsing errors from `req.ParseForm()` are now wrapped as `NewError(err.Error(), 400)` and handled by the error handling in `session.go` after the call to `IAuthentication.Callback()`, resulting in a slightly changed redirect behavior:
> 
>  - **before:** redirect to `/?error=Not%20Valid&trace=parsing%20body%20-<error message>`
>  - **after:** redirect to `/?error=Not%20Allowed&trace=redirect%20request%20failed%20-<error message>`
> 
> If the new redirect behavior is undesirable, it can be adjusted to handle the error differently, although currently, all non-`ErrAuthenticationFailed` errors inside the `Callback()` are treated this way. Alternatively, the second commit can be left out, ignoring the redundancy in favor of simplicity. I'm happy for feedback.
> 
> ---
> 
> Thank you for considering this change to improve the `IAuthentication` interface :)
> 

currently waiting for [frontend rewrite](https://github.com/mickael-kerjean/filestash/issues/629)