### PR TITLE
use input image colorspace for output image

### DIFF
--- a/server/plugin/plg_image_c/image_jpeg.c
+++ b/server/plugin/plg_image_c/image_jpeg.c
@@ -98,7 +98,7 @@ int jpeg_to_jpeg(int inputDesc, int outputDesc, int targetSize) {
   jpeg_config_output.image_width = jpeg_config_input.output_width;
   jpeg_config_output.image_height = jpeg_config_input.output_height;
   jpeg_config_output.input_components = jpeg_config_input.num_components;
-  jpeg_config_output.in_color_space = JCS_RGB;
+  jpeg_config_output.in_color_space = jpeg_config_input.out_color_space;
   jpeg_set_defaults(&jpeg_config_output);
   jpeg_set_quality(&jpeg_config_output, JPEG_QUALITY, TRUE);
   jpeg_start_compress(&jpeg_config_output, TRUE);


### PR DESCRIPTION
Use the colorspace of the input image as the colorspace for the output image in the image_c module, as discussed in here https://github.com/mickael-kerjean/filestash/issues/713#issuecomment-2225491888