### PR TITLE
Add build args: GIT_REPO GIT_REF

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,13 @@
 # STEP1: CLONE THE CODE
 FROM alpine:latest as builder_prepare
 WORKDIR /home/
-RUN apk add git && \
-    git clone --depth 1 https://github.com/mickael-kerjean/filestash
+ARG GIT_REPO=https://github.com/mickael-kerjean/filestash
+ARG GIT_REF=master
+RUN apk add --no-cache git && \
+    git init filestash && \
+    git -C filestash remote add origin ${GIT_REPO} && \
+    git -C filestash fetch --depth 1 origin ${GIT_REF} && \
+    git -C filestash checkout FETCH_HEAD
 
 # STEP2: BUILD THE FRONTEND
 FROM node:18-alpine AS builder_frontend


### PR DESCRIPTION
I think its a good idea to allow building the Docker image from an arbitrary repository and git ref id, otherwise it will always build from your repo at master, which may not be what someone wants. I have set the default ARGS the same as they were before, so this should be identical to the build before if you omit the args.

By the way, my prompt for doing this was that I noticed the latest-arm64 image is much older than the latest (amd64) tag, because I wanted to run the latest version on Raspberry Pi.