### PR TITLE
Updated onlyoffice index.go to respect url behind proxy

### DIFF
--- a/server/plugin/plg_editor_onlyoffice/index.go
+++ b/server/plugin/plg_editor_onlyoffice/index.go
@@ -411,7 +411,7 @@ func IframeContentHandler(ctx *App, res http.ResponseWriter, req *http.Request) 
   <body>
     <style> body { margin: 0; } body, html{ height: 100%%; } iframe { width: 100%%; height: 100%%; } </style>
     <div id="placeholder"></div>
-    <script type="text/javascript" src="/onlyoffice/static/web-apps/apps/api/documents/api.js"></script>
+    <script type="text/javascript" src="%s/web-apps/apps/api/documents/api.js"></script>
     <script>
       if("DocsAPI" in window) loadApplication();
       else sendError("[error] Can't reach the onlyoffice server");
@@ -460,6 +460,7 @@ func IframeContentHandler(ctx *App, res http.ResponseWriter, req *http.Request) 
     </script>
   </body>
 </html>`,
+		server_url(),
 		contentType,
 		oodsDevice,
 		filename,


### PR DESCRIPTION
This change by [JMarcosHP](https://github.com/JMarcosHP) fixes OnlyOffice connection error when run behind nginx proxy manager, reference issue #766