### PR TITLE
`plg_video_{thumbnail,transcoder}`: use common cache directory

### DIFF
--- a/server/plugin/plg_video_thumbnail/index.go
+++ b/server/plugin/plg_video_thumbnail/index.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	VideoCachePath = "data/cache/video-thumbnail/"
+	VideoCacheTmpPath = "video-thumbnail/"
 )
 
 var plugin_enable = func() bool {
@@ -43,7 +43,7 @@ func init() {
 		if plugin_enable() == false {
 			return
 		}
-		cachePath := GetAbsolutePath(VideoCachePath)
+		cachePath := GetAbsolutePath(TMP_PATH, VideoCacheTmpPath)
 		os.RemoveAll(cachePath)
 		os.MkdirAll(cachePath, os.ModePerm)
 
@@ -63,7 +63,7 @@ func (this *ffmpegThumbnail) Generate(reader io.ReadCloser, ctx *App, res *http.
 			"&thumbnail=true", "&origin=plg_video_thumbnail", 1,
 		)
 		cacheName = "thumb_" + GenerateID(ctx.Session) + "_" + QuickHash(req.URL.Query().Get("path"), 10) + ".jpeg"
-		cachePath = GetAbsolutePath(VideoCachePath, cacheName)
+		cachePath = GetAbsolutePath(TMP_PATH, VideoCacheTmpPath, cacheName)
 	)
 
 	reader.Close()

--- a/server/plugin/plg_video_transcoder/index.go
+++ b/server/plugin/plg_video_transcoder/index.go
@@ -23,7 +23,7 @@ const (
 	HLS_SEGMENT_LENGTH = 5
 	FPS                = 30
 	CLEAR_CACHE_AFTER  = 12
-	VideoCachePath     = "data/cache/video/"
+	VideoCacheTmpPath  = "video/"
 )
 
 var (
@@ -79,7 +79,7 @@ func init() {
 		blacklist_format()
 		plugin_enable()
 
-		cachePath := GetAbsolutePath(VideoCachePath)
+		cachePath := GetAbsolutePath(TMP_PATH, VideoCacheTmpPath)
 		os.RemoveAll(cachePath)
 		os.MkdirAll(cachePath, os.ModePerm)
 	})
@@ -129,7 +129,8 @@ func hlsPlaylistHandler(reader io.ReadCloser, ctx *App, res *http.ResponseWriter
 
 	cacheName := "vid_" + GenerateID(ctx.Session) + "_" + QuickHash(path, 10) + ".dat"
 	cachePath := GetAbsolutePath(
-		VideoCachePath,
+		TMP_PATH,
+		VideoCacheTmpPath,
 		cacheName,
 	)
 	f, err := os.OpenFile(cachePath, os.O_CREATE|os.O_RDWR, os.ModePerm)
@@ -179,7 +180,8 @@ func hlsTranscodeHandler(ctx *App, res http.ResponseWriter, req *http.Request) {
 	}
 	startTime := segmentNumber * HLS_SEGMENT_LENGTH
 	cachePath := GetAbsolutePath(
-		VideoCachePath,
+		TMP_PATH,
+		VideoCacheTmpPath,
 		req.URL.Query().Get("path"),
 	)
 	if _, err := os.Stat(cachePath); os.IsNotExist(err) {


### PR DESCRIPTION
`plg_video_thumbnail` and `plg_video_transcoder` use their own hard-coded, non configurable path for cache files. Let's have them use the common, configurable path instead.

I hit this because I'm running filestash in a read-only directory and pointing [FILESTASH_PATH](https://github.com/dermetfan/filestash.nix/blob/2a44e0cb8f032426a3e4a43b09b3fcdb9932b8d3/packages.nix#L155) to configurable locations via symlinks.