### PR TITLE
enh: handle HEAD to healthz

### DIFF
--- a/server/ctrl/report.go
+++ b/server/ctrl/report.go
@@ -2,9 +2,10 @@ package ctrl
 
 import (
 	"fmt"
-	. "github.com/mickael-kerjean/filestash/server/common"
 	"net/http"
 	"os"
+
+	. "github.com/mickael-kerjean/filestash/server/common"
 )
 
 func ReportHandler(ctx *App, res http.ResponseWriter, req *http.Request) {
@@ -69,5 +70,7 @@ func HealthHandler(ctx *App, res http.ResponseWriter, req *http.Request) {
 
 	// SUCCESS!!
 	res.WriteHeader(http.StatusOK)
-	res.Write([]byte(`{"status": "pass"}`))
+	if req.Method != "HEAD" {
+		res.Write([]byte(`{"status": "pass"}`))
+	}
 }

--- a/server/ctrl/report.go
+++ b/server/ctrl/report.go
@@ -22,6 +22,7 @@ func WellKnownSecurityHandler(ctx *App, res http.ResponseWriter, req *http.Reque
 
 func HealthHandler(ctx *App, res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Access-Control-Allow-Origin", "*")
+	res.Header().Set("Content-Type", "application/json")
 	// CHECK 1: open the config file
 	file, err := os.OpenFile(
 		GetAbsolutePath(CONFIG_PATH, "config.json"),

--- a/server/routes.go
+++ b/server/routes.go
@@ -110,7 +110,7 @@ func Build(a App) *mux.Router {
 	r.HandleFunc(WithBase("/robots.txt"), NewMiddlewareChain(RobotsHandler, []Middleware{}, a))
 	r.HandleFunc(WithBase("/manifest.json"), NewMiddlewareChain(ManifestHandler, []Middleware{}, a)).Methods("GET")
 	r.HandleFunc(WithBase("/.well-known/security.txt"), NewMiddlewareChain(WellKnownSecurityHandler, []Middleware{}, a)).Methods("GET")
-	r.HandleFunc(WithBase("/healthz"), NewMiddlewareChain(HealthHandler, []Middleware{}, a)).Methods("GET")
+	r.HandleFunc(WithBase("/healthz"), NewMiddlewareChain(HealthHandler, []Middleware{}, a)).Methods("GET", "HEAD")
 	r.HandleFunc(WithBase("/custom.css"), NewMiddlewareChain(CustomCssHandler, []Middleware{}, a)).Methods("GET")
 	r.PathPrefix(WithBase("/doc")).Handler(NewMiddlewareChain(DocPage, []Middleware{}, a)).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 


### PR DESCRIPTION
Before
```
$ curl -I https://example.com/healthz
HTTP/2 405
status: 405 Method Not Allowed
date: Wed, 08 Jan 2025 03:57:04 GMT
server: nginx
```

After
```
$ curl -I https://example.com/healthz
HTTP/1.1 200 OK
Connection: keep-alive
Status: 200 OK
Access-Control-Allow-Origin: *
Date: Wed, 08 Jan 2025 03:57:10 GMT
Server: nginx
```