### PR TITLE
fix (s3): bug on versitygw

### DIFF
--- a/server/plugin/plg_backend_s3/index.go
+++ b/server/plugin/plg_backend_s3/index.go
@@ -211,11 +211,15 @@ func (this S3Backend) Ls(path string) (files []os.FileInfo, err error) {
 				if i == 0 && *object.Key == p.path {
 					continue
 				}
+				size := 0
+				if object.Size != nil {
+					size = *object.Size
+				}
 				files = append(files, &File{
 					FName: filepath.Base(*object.Key),
 					FType: "file",
 					FTime: object.LastModified.Unix(),
-					FSize: *object.Size,
+					FSize: size,
 				})
 			}
 			for _, object := range objs.CommonPrefixes {


### PR DESCRIPTION
the plugin would break on versitgw which on some version isn't sending the size metadata, ending with a null pointer dereference.

I wasn't able to replicate this on my own but the bug report shows:

2025/01/10 04:35:47 http: panic serving 130.194.66.248:54701: runtime error: invalid memory address or nil pointer dereference goroutine 5590 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x19c2740?, 0x535ece0?})
        /usr/local/go/src/runtime/panic.go:785 +0x132
github.com/mickael-kerjean/filestash/server/plugin/plg_backend_s3.S3Backend.Ls.func1(0xc000986bd0, 0xe0?)
        /home/server/plugin/plg_backend_s3/index.go:218 +0x18a
github.com/aws/aws-sdk-go/service/s3.(*S3).ListObjectsV2PagesWithContext(0xc0005b01a8, {0x46ae758, 0xc000f187e0}, 0xc0006649a0, 0xc0005d7270, {0x0, 0x0, 0x0})
        /home/vendor/github.com/aws/aws-sdk-go/service/s3/api.go:7654 +0x1ad
github.com/mickael-kerjean/filestash/server/plugin/plg_backend_s3.S3Backend.Ls({0xc0005b0178, 0xc00074cd80, 0xc000f188a0, {0x46ae758, 0xc000f187e0}, 0x32}, {0xc0008810f0?, 0x99?})
        /home/server/plugin/plg_backend_s3/index.go:202 +0x31a
github.com/mickael-kerjean/filestash/filestash-enterprise/plugins/utils.wrapper.Ls({{0x46b77c0, 0xc000f18ff0}, {0x5511fc0, 0x0, 0x0}}, {0xc0008810f0?, 0x165dc9a?})
        /home/filestash-enterprise/plugins/utils/authorisation.go:64 +0x94
github.com/mickael-kerjean/filestash/server/ctrl.FileLs(0xc000001d40, {0x46a8bc8, 0xc000f18810}, 0xc000227680)
        /home/server/ctrl/files.go:136 +0x7a2
github.com/mickael-kerjean/filestash/server/middleware.LoggedInOnly.func1(0xc000001d40?, {0x46a8bc8, 0xc000f18810}, 0x0?)
        /home/server/middleware/session.go:23 +0x2e
github.com/mickael-kerjean/filestash/server/middleware.SessionStart.func1(0xc000001d40, {0x46a8bc8, 0xc000f18810}, 0xc000227680)
        /home/server/middleware/session.go:77 +0x2e7
github.com/mickael-kerjean/filestash/server/middleware.WithPublicAPI.func1(0xc000001d40, {0x46a8bc8, 0xc000f18810}, 0xc000227680)
        /home/server/middleware/http.go:115 +0x3a7
github.com/mickael-kerjean/filestash/server/middleware.SecureOrigin.func1(0xc000001d40, {0x46a8bc8, 0xc000f18810}, 0xc000227680)
        /home/server/middleware/http.go:99 +0x4a2
github.com/mickael-kerjean/filestash/server/middleware.SecureHeaders.func1(0xc000001d40, {0x46a8bc8, 0xc000f18810}, 0xc000227680)
        /home/server/middleware/http.go:79 +0x28c
github.com/mickael-kerjean/filestash/server/middleware.ApiHeaders.func1(0xc000001d40, {0x46a8bc8, 0xc000f18810}, 0xc000227680)
        /home/server/middleware/http.go:22 +0x29d
github.com/mickael-kerjean/filestash/server.Build.NewMiddlewareChain.func18({0x46a8cb8, 0xc000904000}, 0xc000227680)
        /home/server/middleware/index.go:28 +0x17b
net/http.HandlerFunc.ServeHTTP(0xc000227540?, {0x46a8cb8?, 0xc000904000?}, 0x52f069?)
        /usr/local/go/src/net/http/server.go:2220 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000000480, {0x46a8cb8, 0xc000904000}, 0xc000227400)
        /home/vendor/github.com/gorilla/mux/mux.go:212 +0x1e2
net/http.serverHandler.ServeHTTP({0xc000c41d40?}, {0x46a8cb8?, 0xc000904000?}, 0x6?)
        /usr/local/go/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc00059d950, {0x46ae758, 0xc000832240})
        /usr/local/go/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 135
        /usr/local/go/src/net/http/server.go:3360 +0x485