### PR TITLE
adapts UI language to the client's language

### DIFF
--- a/server/plugin/plg_editor_wopi/handler.go
+++ b/server/plugin/plg_editor_wopi/handler.go
@@ -282,6 +282,9 @@ func wopiDiscovery(ctx *App, fullpath string) (string, error) {
 	p := u.Query()
 	p.Set("WOPISrc", wopiSRC)
 	p.Set("access_token", ctx.Authorization)
+	if len(ctx.Languages) > 0 {
+		p.Set("lang", ctx.Languages[0])
+	}
 	u.RawQuery = p.Encode()
 	if newHost := rewrite_url(); newHost != "" {
 		if p, err := url.Parse(newHost); err == nil {


### PR DESCRIPTION
#844 According to the UI default language, the UI language of collabora/code must be explicitly specified within the URL( &lang=pt-BR ); otherwise, the UI language will always default to English (en). 