### PR TITLE
chore (refactoring): replace ioutil with io

### DIFF
--- a/server/common/config_state.go
+++ b/server/common/config_state.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -44,7 +44,7 @@ func LoadConfig() ([]byte, error) {
 		}
 		return nil, err
 	}
-	cFile, err := ioutil.ReadAll(file)
+	cFile, err := io.ReadAll(file)
 	file.Close()
 	if err != nil {
 		return nil, err

--- a/server/common/crypto.go
+++ b/server/common/crypto.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"math/big"
 	mathrand "math/rand"
 	"os"
@@ -179,7 +178,7 @@ func decompress(something []byte) ([]byte, error) {
 		return []byte(""), nil
 	}
 	r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func sign(something []byte) ([]byte, error) {

--- a/server/common/ssl/cert.go
+++ b/server/common/ssl/cert.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -45,7 +45,7 @@ func pullCertificateFromFS() (*x509.Certificate, []byte, error) {
 		return nil, nil, err
 	}
 	defer file.Close()
-	certPEM, err := ioutil.ReadAll(file)
+	certPEM, err := io.ReadAll(file)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/common/ssl/private.go
+++ b/server/common/ssl/private.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -43,7 +43,7 @@ func pullPrivateKeyFromFS() (*rsa.PrivateKey, []byte, error) {
 	}
 	defer file.Close()
 
-	keyPEM, err := ioutil.ReadAll(file)
+	keyPEM, err := io.ReadAll(file)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/common/utils.go
+++ b/server/common/utils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 )
 
@@ -68,11 +67,11 @@ func NewStringFromInterface(val interface{}) string {
 }
 
 func NewReadCloserFromBytes(t []byte) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader(t))
+	return io.NopCloser(bytes.NewReader(t))
 }
 
 func NewReadCloserFromReader(r io.Reader) io.ReadCloser {
-	return ioutil.NopCloser(r)
+	return io.NopCloser(r)
 }
 
 func PrettyPrint(json_dirty []byte) []byte {

--- a/server/ctrl/admin.go
+++ b/server/ctrl/admin.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/mickael-kerjean/filestash/server/common"
 	"golang.org/x/crypto/bcrypt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -56,7 +55,7 @@ func AdminSessionAuthenticate(ctx *App, res http.ResponseWriter, req *http.Reque
 		return
 	}
 	var params map[string]string
-	b, _ := ioutil.ReadAll(req.Body)
+	b, _ := io.ReadAll(req.Body)
 	json.Unmarshal(b, &params)
 	if err := bcrypt.CompareHashAndPassword([]byte(admin), []byte(params["password"])); err != nil {
 		SendErrorResult(res, ErrInvalidPassword)

--- a/server/ctrl/config.go
+++ b/server/ctrl/config.go
@@ -2,7 +2,7 @@ package ctrl
 
 import (
 	. "github.com/mickael-kerjean/filestash/server/common"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -13,7 +13,7 @@ func PrivateConfigHandler(ctx *App, res http.ResponseWriter, req *http.Request) 
 }
 
 func PrivateConfigUpdateHandler(ctx *App, res http.ResponseWriter, req *http.Request) {
-	b, _ := ioutil.ReadAll(req.Body)
+	b, _ := io.ReadAll(req.Body)
 	if err := SaveConfig(b); err != nil {
 		SendErrorResult(res, err)
 		return

--- a/server/generator/emacs-el.go
+++ b/server/generator/emacs-el.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -15,7 +15,7 @@ func main() {
 	}
 	defer f.Close()
 
-	j, err := ioutil.ReadAll(f)
+	j, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/server/generator/mime.go
+++ b/server/generator/mime.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -16,7 +16,7 @@ func main() {
 	}
 	defer f.Close()
 
-	j, err := ioutil.ReadAll(f)
+	j, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/server/middleware/context.go
+++ b/server/middleware/context.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	. "github.com/mickael-kerjean/filestash/server/common"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -12,7 +12,7 @@ import (
 func BodyParser(fn HandlerFunc) HandlerFunc {
 	extractBody := func(req *http.Request) (map[string]interface{}, error) {
 		body := map[string]interface{}{}
-		byt, err := ioutil.ReadAll(req.Body)
+		byt, err := io.ReadAll(req.Body)
 		if err != nil {
 			return body, err
 		}

--- a/server/plugin/plg_backend_artifactory/index.go
+++ b/server/plugin/plg_backend_artifactory/index.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	. "github.com/mickael-kerjean/filestash/server/common"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,7 +161,7 @@ func (this ArtifactoryStorage) Ls(path string) ([]os.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	jsonStr, err := ioutil.ReadAll(res.Body)
+	jsonStr, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		Log.Debug("plg_backend_artifactory::ls readall data[%s] status[%d]", string(jsonStr), res.StatusCode)
@@ -190,7 +189,7 @@ func (this ArtifactoryStorage) Cat(path string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	jsonStr, err := ioutil.ReadAll(res.Body)
+	jsonStr, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		Log.Debug("plg_backend_artifactory::cat readall data[%s] status[%d]", string(jsonStr), res.StatusCode)
@@ -269,7 +268,7 @@ func (this ArtifactoryStorage) Mkdir(path string) error {
 	if err != nil {
 		return err
 	}
-	jsonStr, err := ioutil.ReadAll(res.Body)
+	jsonStr, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		Log.Debug("plg_backend_artifactory::mkdir readall status[%d] data[%s]", res.StatusCode, string(jsonStr))
@@ -307,7 +306,7 @@ func (this ArtifactoryStorage) Rm(path string) error {
 	if err != nil {
 		return err
 	}
-	jsonStr, err := ioutil.ReadAll(res.Body)
+	jsonStr, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		Log.Debug("plg_backend_artifactory::rm readall status[%d] data[%s]", res.StatusCode, string(jsonStr))
@@ -336,7 +335,7 @@ func (this ArtifactoryStorage) Mv(from, to string) error {
 	if err != nil {
 		return err
 	}
-	jsonStr, err := ioutil.ReadAll(res.Body)
+	jsonStr, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		Log.Debug("plg_backend_artifactory::mv readall status[%d] data[%s]", res.StatusCode, string(jsonStr))
@@ -367,7 +366,7 @@ func (this ArtifactoryStorage) Save(path string, content io.Reader) error {
 	if err != nil {
 		return err
 	}
-	jsonStr, err := ioutil.ReadAll(res.Body)
+	jsonStr, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		Log.Debug("plg_backend_artifactory::save readall status[%d] data[%s]", res.StatusCode, string(jsonStr))

--- a/server/plugin/plg_backend_backblaze/index.go
+++ b/server/plugin/plg_backend_backblaze/index.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -56,7 +55,7 @@ func (this Backblaze) Init(params map[string]string, app *App) (IBackend, error)
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return nil, err
@@ -79,7 +78,7 @@ func (this Backblaze) Init(params map[string]string, app *App) (IBackend, error)
 	if err != nil {
 		return nil, err
 	}
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return nil, err
@@ -153,7 +152,7 @@ func (this Backblaze) Ls(path string) ([]os.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return nil, err
@@ -222,7 +221,7 @@ func (this Backblaze) Mkdir(path string) error {
 		if err != nil {
 			return err
 		}
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			return err
@@ -260,7 +259,7 @@ func (this Backblaze) Rm(path string) error {
 		if err != nil {
 			return err
 		}
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			return err
@@ -289,7 +288,7 @@ func (this Backblaze) Rm(path string) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return err
@@ -317,7 +316,7 @@ func (this Backblaze) Rm(path string) error {
 		if err != nil {
 			return err
 		}
-		if body, err = ioutil.ReadAll(res.Body); err != nil {
+		if body, err = io.ReadAll(res.Body); err != nil {
 			return err
 		}
 		res.Body.Close()
@@ -349,7 +348,7 @@ func (this Backblaze) Touch(path string) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return err
@@ -378,7 +377,7 @@ func (this Backblaze) Touch(path string) error {
 	if err != nil {
 		return err
 	}
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return err
@@ -406,7 +405,7 @@ func (this Backblaze) Save(path string, file io.Reader) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return err
@@ -468,7 +467,7 @@ func (this Backblaze) Save(path string, file io.Reader) error {
 	if err != nil {
 		return err
 	}
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return err

--- a/server/plugin/plg_backend_dav/index.go
+++ b/server/plugin/plg_backend_dav/index.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	. "github.com/mickael-kerjean/filestash/server/common"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -201,7 +200,7 @@ func (this Dav) Mv(from string, to string) error {
 	if err != nil {
 		return err
 	}
-	d, err := ioutil.ReadAll(reader)
+	d, err := io.ReadAll(reader)
 	if err != nil {
 		return ErrNotValid
 	}

--- a/server/plugin/plg_backend_dropbox/index.go
+++ b/server/plugin/plg_backend_dropbox/index.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	. "github.com/mickael-kerjean/filestash/server/common"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -123,7 +122,7 @@ func (d Dropbox) Cat(path string) (io.ReadCloser, error) {
 		arg := struct {
 			Path string `json:"path"`
 		}{d.path(path)}
-		json, _ := ioutil.ReadAll(d.toReader(arg))
+		json, _ := io.ReadAll(d.toReader(arg))
 		req.Header.Set("Dropbox-API-Arg", string(json))
 	})
 	if err != nil {
@@ -184,7 +183,7 @@ func (d Dropbox) Save(path string, file io.Reader) error {
 			AutoRename bool   `json:"autorename"`
 			Mode       string `json:"mode"`
 		}{d.path(path), false, "overwrite"}
-		json, _ := ioutil.ReadAll(d.toReader(arg))
+		json, _ := io.ReadAll(d.toReader(arg))
 		req.Header.Set("Dropbox-API-Arg", string(json))
 		req.Header.Set("Content-Type", "application/octet-stream")
 	})

--- a/server/plugin/plg_image_bimg/index.go
+++ b/server/plugin/plg_image_bimg/index.go
@@ -4,7 +4,6 @@ import (
 	"github.com/h2non/bimg"
 	. "github.com/mickael-kerjean/filestash/server/common"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -28,7 +27,7 @@ func (this thumbnailer) Generate(reader io.ReadCloser, ctx *App, res *http.Respo
 		return reader, nil
 	}
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return reader, err
 	}

--- a/server/plugin/plg_security_svg/index.go
+++ b/server/plugin/plg_security_svg/index.go
@@ -3,7 +3,6 @@ package plg_security_svg
 import (
 	. "github.com/mickael-kerjean/filestash/server/common"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"regexp"
 )
@@ -42,7 +41,7 @@ func init() {
 			(*res).Header().Set("Content-Security-Policy", "script-src 'none'; default-src 'none'; img-src 'self'")
 			(*res).Header().Set("Content-Type", "text/plain")
 			// XML bomb
-			txt, _ := ioutil.ReadAll(reader)
+			txt, _ := io.ReadAll(reader)
 			if regexp.MustCompile("(?is)entity").Match(txt) {
 				txt = []byte("")
 			}


### PR DESCRIPTION
Replace ioutil with io, as ioutil has been deprecated since Go 1.16.