### PR TITLE
Fix safari asset url resolution bug

### DIFF
--- a/public/index.frontoffice.html
+++ b/public/index.frontoffice.html
@@ -84,10 +84,10 @@
              } catch (err) { console.error(err); }
 
              await Promise.all([
-                 import("./assets/{{ .version }}/components/loader.js"),
-                 import("./assets/{{ .version }}/components/modal.js"),
-                 import("./assets/{{ .version }}/components/notification.js"),
-                 import("./assets/{{ .version }}/helpers/loader.js").then(({ loadCSS }) => {
+                 import("{{ .base }}assets/{{ .version }}/components/loader.js"),
+                 import("{{ .base }}assets/{{ .version }}/components/modal.js"),
+                 import("{{ .base }}assets/{{ .version }}/components/notification.js"),
+                 import("{{ .base }}assets/{{ .version }}/helpers/loader.js").then(({ loadCSS }) => {
                      loadCSS(import.meta.url, "{{ .base }}assets/{{ .version }}/css/designsystem.css");
                  }),
              ]);


### PR DESCRIPTION
(Copied from the original issue:)
On Safari, when accessing the app from the login page or from the root endpoint `https://demo.filestash.app/`, the application works just fine.
But when reloading the page, or trying to access `https://demo.filestash.app/files/` via the address bar, it gets stuck on the loading page.

The issue is in the following script loading code:
```
import("./assets/{{ .version }}/components/loader.js"),
import("./assets/{{ .version }}/components/modal.js"),
import("./assets/{{ .version }}/components/notification.js"),
import("./assets/{{ .version }}/helpers/loader.js").then(({ loadCSS }) ...
```

It seems like safari is resolving the `./assets` path to be the relative path, disregarding the `<base href="/">` tag.
Not sure if it's a Safari bug, but changing the server to generate the base url (instead of relying on js to resolve the script location) should make it work.
```
import("{{ .base }}assets/{{ .version }}/components/loader.js"),
import("{{ .base }}assets/{{ .version }}/components/modal.js"),
import("{{ .base }}assets/{{ .version }}/components/notification.js"),
import("{{ .base }}assets/{{ .version }}/helpers/loader.js").then(({ loadCSS }) ...
```


Fixes #888.