### PR TITLE
chore(cgo): allow for non-cgo builds

### DIFF
--- a/server/plugin/plg_image_c/index.go
+++ b/server/plugin/plg_image_c/index.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package plg_image_c
 
 import (

--- a/server/plugin/plg_image_c/index_nocgo.go
+++ b/server/plugin/plg_image_c/index_nocgo.go
@@ -1,0 +1,3 @@
+//go:build !cgo
+
+package plg_image_c


### PR DESCRIPTION
Allows for building and running without CGO. The following is a snippet from my darwin ARM machine, but the Dockerfile also works if I simply add a CGO_ENABLED=0

This has the effect of disabling thumbnail generation which could be a choice for ppl to make.

```
➜  filestash git:(chore/allow-non-cgo-build) CGO_ENABLED=0 go run cmd/main.go
# github.com/mickael-kerjean/filestash/server/plugin/plg_image_c
server/plugin/plg_image_c/index.go:29:62: undefined: jpeg
server/plugin/plg_image_c/index.go:30:61: undefined: png
server/plugin/plg_image_c/index.go:31:61: undefined: gif
server/plugin/plg_image_c/index.go:32:62: undefined: webp
server/plugin/plg_image_c/index.go:42:56: undefined: raw
server/plugin/plg_image_c/index.go:62:35: undefined: raw

➜  filestash git:(chore/allow-non-cgo-build) git pull
Updating 5bd6961d..278d7960
Fast-forward
 server/plugin/plg_image_c/index.go       | 2 ++
 server/plugin/plg_image_c/index_nocgo.go | 3 +++
 2 files changed, 5 insertions(+)
 create mode 100644 server/plugin/plg_image_c/index_nocgo.go

➜  filestash git:(chore/allow-non-cgo-build) CGO_ENABLED=0 go run cmd/main.go
2026/02/06 10:53:58 SYST WARN plg_video_thumbnail::init error=ffmpeg_not_installed
2026/02/06 10:53:58 SYST INFO [http] starting ...
2026/02/06 10:53:58 SYST INFO [http] listening on :8334
```