### PR TITLE
fix (config): deterministic JSON key ordering for config.json

### DIFF
--- a/server/common/config.go
+++ b/server/common/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -183,6 +184,57 @@ func formToJSON(f Form, fn func(FormElement) any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func marshalSortedMap(m map[string]any) ([]byte, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		key, _ := json.Marshal(k)
+		buf.Write(key)
+		buf.WriteByte(':')
+		switch val := m[k].(type) {
+		case map[string]any:
+			v, err := marshalSortedMap(val)
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(v)
+		default:
+			v, err := json.Marshal(val)
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(v)
+		}
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+func marshalSortedMapSlice(s []map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i, m := range s {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		v, err := marshalSortedMap(m)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(v)
+	}
+	buf.WriteByte(']')
+	return buf.Bytes(), nil
+}
+
 func (this *Configuration) Load() error {
 	cFile, err := LoadConfig()
 	if err != nil {
@@ -262,7 +314,7 @@ func (this *Configuration) Initialise() {
 func (this *Configuration) Save() {
 	this.mu.RLock()
 	formBytes, err := formToJSON(Form{Form: this.Form}, func(el FormElement) any { return el.Value })
-	conn, _ := json.Marshal(this.Conn)
+	conn, _ := marshalSortedMapSlice(this.Conn)
 	this.mu.RUnlock()
 	if err != nil {
 		Log.Error("config::save marshal %s", err.Error())


### PR DESCRIPTION
## Summary

- The `connections` field (`[]map[string]any`) in config was serialized using `json.Marshal`, which produces non-deterministic key ordering due to Go's random map iteration order
- This caused spurious diffs when `config.json` is kept under version control — keys would randomly reorder on every save even when no actual values changed
- Replaced `json.Marshal` with a custom marshaler that sorts map keys alphabetically before serialization, ensuring stable and deterministic output

## Test plan

- [ ] Verify config saves produce identical output when no values have changed
- [ ] Verify config saves correctly reflect actual value changes
- [ ] Verify nested map values in connections are also sorted deterministically