### PR TITLE
FTP: add connect strategy labels and select placeholder support

### DIFF
--- a/public/assets/components/form.js
+++ b/public/assets/components/form.js
@@ -56,6 +56,7 @@ export function $renderInput(options = {}) {
             path = [],
             datalist = null,
             options = null,
+            options_label = null,
             pattern = null,
         } = props;
 
@@ -231,12 +232,14 @@ export function $renderInput(options = {}) {
             if (!($select instanceof HTMLSelectElement)) throw new ApplicationError("INTERNAL_ERROR", "assumption failed: missing input");
             else if (value) $select.value = value || props.default;
             attrs.map((setAttribute) => setAttribute($select));
-            (options || []).forEach((name) => {
+            (options || []).forEach((name, index) => {
                 const $option = createElement(`
                     <option></option>
                 `);
-                $option.textContent = name;
+                const label = Array.isArray(options_label) ? options_label[index] : null;
+                $option.textContent = (label || ((name === "" && placeholder) ? placeholder : name));
                 $option.setAttribute("name", name);
+                $option.setAttribute("value", name);
                 if (name === (value || props.default)) {
                     $option.setAttribute("selected", "");
                 }

--- a/server/common/config.go
+++ b/server/common/config.go
@@ -39,6 +39,7 @@ type FormElement struct {
 	Placeholder string      `json:"placeholder,omitempty"`
 	Pattern     string      `json:"pattern,omitempty"`
 	Opts        []string    `json:"options,omitempty"`
+	OptsLabel   []string    `json:"options_label,omitempty"`
 	Target      []string    `json:"target,omitempty"`
 	ReadOnly    bool        `json:"readonly"`
 	Default     interface{} `json:"default"`

--- a/server/plugin/plg_backend_ftp/index.go
+++ b/server/plugin/plg_backend_ftp/index.go
@@ -85,7 +85,9 @@ func (f Ftp) Init(params map[string]string, app *App) (IBackend, error) {
 	}
 
 	connectStrategy := []string{"ftp", "ftps::implicit", "ftps::explicit"}
-	if strings.HasPrefix(params["hostname"], "ftp://") {
+	if params["connect_strategy"] != "" {
+		connectStrategy = []string{params["connect_strategy"]}
+	} else if strings.HasPrefix(params["hostname"], "ftp://") {
 		connectStrategy = []string{"ftp"}
 		params["hostname"] = strings.TrimPrefix(params["hostname"], "ftp://")
 	} else if strings.HasPrefix(params["hostname"], "ftps://") {
@@ -212,7 +214,7 @@ func (f Ftp) LoginForm() Form {
 				Name:        "advanced",
 				Type:        "enable",
 				Placeholder: "Advanced",
-				Target:      []string{"ftp_path", "ftp_port", "ftp_conn"},
+				Target:      []string{"ftp_path", "ftp_port", "ftp_conn", "ftp_connect_strategy"},
 			},
 			{
 				Id:          "ftp_path",
@@ -231,6 +233,14 @@ func (f Ftp) LoginForm() Form {
 				Name:        "conn",
 				Type:        "number",
 				Placeholder: "Number of connections",
+			},
+			{
+				Id:          "ftp_connect_strategy",
+				Name:        "connect_strategy",
+				Type:        "select",
+				Placeholder: "Connection strategy",
+				Opts:        []string{"", "ftp", "ftps::implicit", "ftps::explicit"},
+				OptsLabel:   []string{"Auto", "FTP", "FTPS (Implicit TLS)", "FTPS (Explicit TLS)"},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
This MR improves the FTP backend configuration UX by adding explicit connection strategy selection with user-friendly labels, while preserving stable internal values.

## What Changed
- Added support for display labels alongside option values in select fields.
- Updated FTP `connect_strategy` options to show readable labels (`Auto`, `FTP`, `FTPS (Implicit TLS)`, `FTPS (Explicit TLS)`) while keeping canonical submitted values.
- Improved select rendering so empty/default choices are shown with a visible placeholder instead of a blank entry.
- Kept existing behavior backward-compatible for forms that only provide values.

<img width="1413" height="554" alt="image" src="https://github.com/user-attachments/assets/1e519b13-0fce-4f3d-8856-4f3790847a3d" />

