### PR TITLE
fix compilation problems on FreeBSD

### DIFF
--- a/server/pkg/compress/cgo.go
+++ b/server/pkg/compress/cgo.go
@@ -1,4 +1,4 @@
-//go:build cgo && linux
+//go:build cgo && linux || freebsd
 
 package compress
 

--- a/server/plugin/plg_image_c/image_png_freebsd.go
+++ b/server/plugin/plg_image_c/image_png_freebsd.go
@@ -1,7 +1,7 @@
 package plg_image_c
 
 // #include "image_png.h"
-// #cgo LDFLAGS: -L /usr/local/lib -L /usr/lib -L /lib -l:libsharpyuv.a -l:libpng.a -l:libz.a -l:libwebp.a -l:libpthread.a -fopenmp
+// #cgo LDFLAGS: -L /usr/local/lib -L /usr/lib -L /lib -l:libsharpyuv.a -l:libpng.a -l:libz.a -l:libwebp.a -fopenmp
 // #cgo CFLAGS: -I /usr/local/include
 import "C"
 


### PR DESCRIPTION
This PR resoves the issue #954 


It seems that the libpthread is not needed anymore in the LDFLAGS for plg_image_c/image_png plugin, it breaks at compilation and I had success removing it.

I also had to add freebsd as a target in the compress package.


For info, you still need to set up the CFLAGS env vars to copile on Freebsd. It is need for google's brotli package.

export CGO_CFLAGS="-I/usr/local/include" 
export CGO_LDFLAGS="-L/usr/local/lib -L/usr/lib -L/lib"

Tested in freebsd15 and it works. (I also try uploading a png file and the thumbnail is ok)

The changes are made to only target freebsd, this should have no impact.
