### PR TITLE
fix (admin): fully hide admin menu in step1 on small screens

### DIFF
--- a/public/assets/pages/adminpage/animate.js
+++ b/public/assets/pages/adminpage/animate.js
@@ -7,4 +7,4 @@ export default function($node) {
     });
 }
 
-export const cssHideMenu = ".component_menu_sidebar{transform: translateX(-300px)}";
+export const cssHideMenu = ".component_menu_sidebar{transform: translateX(-525px)}";


### PR DESCRIPTION
Hello,

I noticed a strange behavior while playing with the app on my phone. The admin menu is not hidden properly on small screens <500px.
<img width="555" height="396" alt="before" src="https://github.com/user-attachments/assets/64cd81b1-e5d4-4be0-a322-a6cdcb2dae77" />
<img width="537" height="413" alt="after" src="https://github.com/user-attachments/assets/abed90e5-662e-48a9-87a2-43c28c0f52ff" />

So here is the fix 
