### PR TITLE
feat(plg_sftp_backend): use ssh session to rm -r

### DIFF
--- a/server/plugin/plg_backend_sftp/index.go
+++ b/server/plugin/plg_backend_sftp/index.go
@@ -284,6 +284,13 @@ func (b Sftp) Mkdir(path string) error {
 
 func (b Sftp) Rm(path string) error {
 	if IsDirectory(path) {
+		err := b.rmSsh(path)
+		if err != nil {
+			Log.Info("plg_backend_sftp::sftp could not rm -r via the SSH session, falling back to SFTP method", "error", err.Error())
+		} else {
+			return nil
+		}
+
 		list, err := b.SFTPClient.ReadDir(path)
 		if err != nil {
 			return b.err(err)
@@ -430,4 +437,19 @@ func (b Sftp) err(e error) error {
 	default:
 		return NewError("Oops! Something went wrong", 500)
 	}
+}
+
+func (b Sftp) rmSsh(path string) error {
+	session, err := b.SSHClient.NewSession()
+	if err != nil {
+		return err
+	}
+
+	defer session.Close()
+	err = session.Run("rm -r '" + strings.ReplaceAll(path, "'", "'\\''") + "'")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
**Changes:**
This modification updates the `plg_sftp_backend plugin`. When a deletion request targets a directory, the system now prioritizes executing `rm -r` via SSH.

**Fallback Mechanism:**
If the SSH execution fails, the process gracefully falls back to the original recursive SFTP method. Any errors encountered during the SSH attempt are logged for debugging.

**Why this change?**
The previous recursive SFTP approach often resulted in timeouts when deleting large folders due to network overhead. Using SSH `rm -r` executes the deletion server-side in a single command.