### PR TITLE
fix (plg_backend_sftp): guard Sftp.Close against nil clients

### DIFF
--- a/server/plugin/plg_backend_sftp/index.go
+++ b/server/plugin/plg_backend_sftp/index.go
@@ -345,9 +345,13 @@ func (b Sftp) Stat(path string) (os.FileInfo, error) {
 }
 
 func (b Sftp) Close() error {
-	err0 := b.SFTPClient.Close()
-	err1 := b.SSHClient.Close()
-
+	var err0, err1 error
+	if b.SFTPClient != nil {
+		err0 = b.SFTPClient.Close()
+	}
+	if b.SSHClient != nil {
+		err1 = b.SSHClient.Close()
+	}
 	if err0 != nil {
 		return err0
 	}


### PR DESCRIPTION
Repro:
- log in with valid SFTP credentials
- make the SFTP server unreachable (delete the user, stop the daemon)
- click logout: SessionLogout -> SessionTry -> _extractBackend reconnects, ssh.Dial fails, Init returns a Sftp with SSHClient=nil and SFTPClient=nil
- SessionLogout calls Close() on it and the goroutine panics with nil pointer dereference at index.go

Change:
- nil-check b.SFTPClient and b.SSHClient before calling Close() so a partially-initialised Sftp can be torn down safely

Fixes #985