### PR TITLE
fix (webdav): client without trailing slash

### DIFF
--- a/server/model/webdav.go
+++ b/server/model/webdav.go
@@ -79,6 +79,7 @@ func (this *WebdavFs) OpenFile(ctx context.Context, name string, flag int, perm 
 		backend: this.backend,
 		cache:   cachePath,
 		fwrite:  fwriteFile(),
+		isDir:   false,
 	}
 	return this.webdavFile, nil
 }
@@ -105,11 +106,8 @@ func (this *WebdavFs) Stat(ctx context.Context, name string) (os.FileInfo, error
 		return this.webdavFile.Stat()
 	}
 	fullname := this.fullpath(name)
-	if isMicrosoftWebDAVClient(this.req) && this.req.Method == "PROPFIND" {
-		if name == "" {
-			fullname = this.chroot
-		}
-		fullname = EnforceDirectory(fullname)
+	if name == "" {
+		fullname = this.chroot
 	}
 	if fullname == "" {
 		return nil, os.ErrNotExist
@@ -118,6 +116,7 @@ func (this *WebdavFs) Stat(ctx context.Context, name string) (os.FileInfo, error
 		path:    fullname,
 		backend: this.backend,
 		cache:   filepath.Join(GetAbsolutePath(TMP_PATH), "webdav_"+Hash(this.id+name, 20)),
+		isDir:   strings.HasSuffix(fullname, "/"),
 	}
 	return this.webdavFile.Stat()
 }
@@ -143,6 +142,7 @@ type WebdavFile struct {
 	fread   *os.File
 	fwrite  *os.File
 	files   []os.FileInfo
+	isDir   bool
 }
 
 func (this *WebdavFile) Read(p []byte) (n int, err error) {
@@ -206,6 +206,7 @@ func (this *WebdavFile) Stat() (os.FileInfo, error) {
 		if err != nil {
 			return nil, os.ErrNotExist
 		}
+		this.isDir = true
 		return this, nil
 	}
 	baseDir := filepath.Base(this.path)
@@ -216,6 +217,7 @@ func (this *WebdavFile) Stat() (os.FileInfo, error) {
 	found := false
 	for i := range files {
 		if files[i].Name() == baseDir {
+			this.isDir = files[i].IsDir()
 			found = true
 			break
 		}
@@ -301,10 +303,7 @@ func (this WebdavFile) ModTime() time.Time {
 	return time.Now()
 }
 func (this WebdavFile) IsDir() bool {
-	if strings.HasSuffix(this.path, "/") {
-		return true
-	}
-	return false
+	return this.isDir
 }
 
 func (this WebdavFile) Sys() interface{} {
@@ -333,8 +332,4 @@ func NewWebdavLock() webdav.LockSystem {
 		lock = webdav.NewMemLS()
 	}
 	return lock
-}
-
-func isMicrosoftWebDAVClient(req *http.Request) bool {
-	return strings.HasPrefix(req.Header.Get("User-Agent"), "Microsoft-WebDAV-MiniRedir/")
 }

--- a/server/model/webdav.go
+++ b/server/model/webdav.go
@@ -84,20 +84,38 @@ func (this *WebdavFs) OpenFile(ctx context.Context, name string, flag int, perm 
 	return this.webdavFile, nil
 }
 
+// statIsDir uses a throwaway WebdavFile on purpose. WebdavFs.Stat caches the
+// first file it sees and returns it on every later call, ignoring the name
+// argument. During a MOVE the library stats the destination before Rename, so
+// going through it would answer for the wrong path.
+func (this WebdavFs) statIsDir(fullname string) bool {
+	f := &WebdavFile{path: fullname, backend: this.backend}
+	info, err := f.Stat()
+	return err == nil && info.IsDir()
+}
+
 func (this WebdavFs) RemoveAll(ctx context.Context, name string) error {
-	if name = this.fullpath(name); name == "" {
+	fullname := this.fullpath(name)
+	if fullname == "" {
 		return os.ErrNotExist
 	}
-	return this.backend.Rm(name)
+	if strings.HasSuffix(fullname, "/") == false && this.statIsDir(fullname) {
+		fullname = EnforceDirectory(fullname)
+	}
+	return this.backend.Rm(fullname)
 }
 
 func (this WebdavFs) Rename(ctx context.Context, oldName, newName string) error {
-	if oldName = this.fullpath(oldName); oldName == "" {
-		return os.ErrNotExist
-	} else if newName = this.fullpath(newName); newName == "" {
+	oldPath := this.fullpath(oldName)
+	newPath := this.fullpath(newName)
+	if oldPath == "" || newPath == "" {
 		return os.ErrNotExist
 	}
-	return this.backend.Mv(oldName, newName)
+	if strings.HasSuffix(oldPath, "/") == false && this.statIsDir(oldPath) {
+		oldPath = EnforceDirectory(oldPath)
+		newPath = EnforceDirectory(newPath)
+	}
+	return this.backend.Mv(oldPath, newPath)
 }
 
 func (this *WebdavFs) Stat(ctx context.Context, name string) (os.FileInfo, error) {

--- a/server/model/webdav.go
+++ b/server/model/webdav.go
@@ -194,7 +194,7 @@ func (this *WebdavFile) Readdir(count int) ([]os.FileInfo, error) {
 	if strings.HasPrefix(filepath.Base(this.path), ".") {
 		return nil, os.ErrNotExist
 	}
-	f, err := this.backend.Ls(this.path)
+	f, err := this.backend.Ls(EnforceDirectory(this.path))
 	this.files = f
 	return f, err
 }


### PR DESCRIPTION
## Summary

Some WebDAV clients send PROPFIND without a trailing slash. This happens on the share root and on sub-folders. Two separate problems made these requests fail.

1. On the share root the request name resolves to an empty string. The path builder runs filepath.Join(chroot, "") which drops the trailing slash, then the chroot guard HasPrefix(p, chroot) rejects the now slash-less path, so Stat returns ErrNotExist and the client gets a 404.

2. On sub-folders and files the type was inferred from a trailing slash on the path string. A collection requested without the slash was reported as a file, so the PROPFIND was handled incorrectly.

The earlier fix (f53dc6a7 "network drive via window") worked around both for Microsoft clients only, by setting the root path to the chroot and forcing EnforceDirectory on every Windows PROPFIND. Other clients stayed broken.

## Fix

Two changes, neither tied to a user agent.

1. For the share root (name == "") use the chroot directly instead of  filepath.Join. This yields the exact same path the trailing-slash request already produced, so the broken input now follows the existing working path.

2. Stop inferring file vs directory from URL syntax. In WebdavFile.Stat the parent Ls already returns each entry's IsDir() from the backend. We capture it onto WebdavFile.isDir and have WebdavFile.IsDir() read that field. The directory branch sets it to true after a successful Readdir. Both places that build a WebdavFile set it too: Stat falls back to the slash for the brief moment before it runs, and OpenFile's create branch is always a PUT so it is a file.

With the type now coming from the backend, the Microsoft-specific EnforceDirectory workaround and the isMicrosoftWebDAVClient helper are no longer needed and are removed.

## Test plan

i have verified all of them against a live docker deployment running the fix.

- [x] Share root, no trailing slash, 207 (MaterialFiles, Windows Explorer, curl)
- [x] Share root, with trailing slash, 207
- [x] Sub-folder, no trailing slash, 207 and reported as a collection
- [x] File with no extension and no trailing slash, 207 and reported as non-collection
- [x] Regular file PROPFIND, 207 and non-collection
- [x] Non-existent path, 404
- [x] GET file content, 200
- [x] OPTIONS on root, 200 with DAV: 1, 2
- [x] Delete a folder without the trailing slash, a neighbouring folder sharing the name prefix is left intact
- [x] Move a folder without the trailing slash, the neighbouring folder is left intact

Fixes #756