### PR TITLE
fix (webdav): challenge with 401 instead of 400 on protected shares (fix password auth not working on some clients like the windows one)

### DIFF
--- a/server/middleware/session.go
+++ b/server/middleware/session.go
@@ -82,6 +82,39 @@ func SessionStart(fn HandlerFunc) HandlerFunc {
 	})
 }
 
+func WebdavSessionStart(fn HandlerFunc) HandlerFunc {
+	return HandlerFunc(func(ctx *App, res http.ResponseWriter, req *http.Request) {
+		var err error
+
+		if ctx.Share, err = _extractShare(req); err != nil {
+			if err == errShareProofRequired {
+				res.Header().Set("WWW-Authenticate", `Basic realm="Filestash"`)
+				res.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			SendErrorResult(res, err)
+			return
+		}
+		ctx.Authorization = _extractAuthorization(req)
+		if ctx.Session, err = _extractSession(req, ctx); err != nil {
+			RecoverFromBadCookie(res)
+			SendErrorResult(res, err)
+			return
+		}
+		if ctx.Backend, err = _extractBackend(req, ctx); err != nil {
+			if len(ctx.Session) == 0 {
+				SendErrorResult(res, ErrNotAuthorized)
+				return
+			}
+			SendErrorResult(res, err)
+			return
+		}
+		ctx.Languages = _extractLanguages(req)
+
+		fn(ctx, res, req)
+	})
+}
+
 func SessionTry(fn HandlerFunc) HandlerFunc {
 	return HandlerFunc(func(ctx *App, res http.ResponseWriter, req *http.Request) {
 		ctx.Share, _ = _extractShare(req)
@@ -199,6 +232,8 @@ func _extractShareId(req *http.Request) string {
 	return m
 }
 
+var errShareProofRequired = NewError("Unauthorized Shared space", 400)
+
 func _extractShare(req *http.Request) (Share, error) {
 	var err error
 	share_id := _extractShareId(req)
@@ -254,7 +289,7 @@ func _extractShare(req *http.Request) (Share, error) {
 	var requiredProof []model.Proof = model.ShareProofGetRequired(s)
 	var remainingProof []model.Proof = model.ShareProofCalculateRemainings(requiredProof, verifiedProof)
 	if len(remainingProof) != 0 {
-		return Share{}, NewError("Unauthorized Shared space", 400)
+		return Share{}, errShareProofRequired
 	}
 	return s, nil
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -87,7 +87,7 @@ func Build(r *mux.Router) {
 	// Webdav server / Shared Link
 	middlewares = []Middleware{IndexHeaders, SecureHeaders, PluginInjector}
 	r.HandleFunc(WithBase("/s/{share}"), NewMiddlewareChain(ServeFrontofficeHandler, middlewares)).Methods("GET")
-	middlewares = []Middleware{WebdavBlacklist, SessionStart, PluginInjector}
+	middlewares = []Middleware{WebdavBlacklist, WebdavSessionStart, PluginInjector}
 	r.PathPrefix(WithBase("/s/{share}")).Handler(NewMiddlewareChain(WebdavHandler, middlewares))
 
 	// Application Resources


### PR DESCRIPTION
## Summary

When a shared link has a password or a user restriction, mounting it over WebDAV fails with an error, while the same link mounts fine once the password is removed. Reported in #962.

The cause is the HTTP status the share returns. When the proof is missing, `_extractShare` (`server/middleware/session.go`) returns a `400` (before):

```go
return Share{}, NewError("Unauthorized Shared space", 400)
```

WebDAV does not define its own authentication, it relies on HTTP auth, which is challenge-response. Most clients only sends credentials after they gets a `401` with a `WWW-Authenticate` header (RFC 7235 in part 3.1, and `Basic` from RFC 7617). A bare `400` gives nothing to authenticate against, so it never prompts and treats the endpoint as invalid. With auth off, `_extractShare` returns no error and the mount works wich is why it works without.

## Fix

Add a `WebdavSessionStart` middleware, used only on the `/s/` webdav route. It mirrors `SessionStart` but answers the "missing-proof" case with `401` + `WWW-Authenticate: Basic realm="Filestash"`. Any other share error keeps their original status.

## Tests

Set up a password protected folder share.

- [X] Mount from Windows Explorer, you get a credentials prompt and any username + the share password works
- [X] Mount from MaterialFiles
- [X] `curl -i -X PROPFIND https://host/s/{id}` returns `401` with a `WWW-Authenticate` header
- [X] `curl -i -X PROPFIND -u x:thepassword https://host/s/{id}` returns `207`
- [X] A share with no auth still mounts as before
- [X] An expired link still returns its normal error, not an auth prompt

Fixes #962