### PR TITLE
fix (s3/azure): folder delete and move no longer affect sibling folders

### DIFF
--- a/server/plugin/plg_backend_azure/index.go
+++ b/server/plugin/plg_backend_azure/index.go
@@ -89,9 +89,13 @@ func (this *AzureBlob) Ls(path string) ([]os.FileInfo, error) {
 		return files, nil
 	}
 
+	prefix := ap.blobName
+	if prefix != "" {
+		prefix = EnforceDirectory(prefix)
+	}
 	client := this.client.ServiceClient().NewContainerClient(ap.containerName)
 	pager := client.NewListBlobsHierarchyPager("/", &container.ListBlobsHierarchyOptions{
-		Prefix: &ap.blobName,
+		Prefix: &prefix,
 	})
 	for pager.More() {
 		resp, err := pager.NextPage(this.ctx)
@@ -243,9 +247,13 @@ func (this *AzureBlob) Rm(path string) error {
 		_, err := this.client.DeleteBlob(this.ctx, ap.containerName, ap.blobName, nil)
 		return err
 	}
+	prefix := ap.blobName
+	if prefix != "" {
+		prefix = EnforceDirectory(prefix)
+	}
 	pager := this.client.NewListBlobsFlatPager(ap.containerName, &container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true, Versions: true},
-		Prefix:  &ap.blobName,
+		Prefix:  &prefix,
 	})
 	for pager.More() {
 		resp, err := pager.NextPage(this.ctx)
@@ -289,9 +297,17 @@ func (this *AzureBlob) Mv(from string, to string) error {
 	}
 
 	// CASE 2: Move a directory
+	fromPrefix := apFrom.blobName
+	if fromPrefix != "" {
+		fromPrefix = EnforceDirectory(fromPrefix)
+	}
+	toPrefix := apTo.blobName
+	if toPrefix != "" {
+		toPrefix = EnforceDirectory(toPrefix)
+	}
 	pager := this.client.NewListBlobsFlatPager(apFrom.containerName, &container.ListBlobsFlatOptions{
 		Include: container.ListBlobsInclude{Snapshots: true, Versions: true},
-		Prefix:  &apFrom.blobName,
+		Prefix:  &fromPrefix,
 	})
 	for pager.More() {
 		resp, err := pager.NextPage(this.ctx)
@@ -305,7 +321,7 @@ func (this *AzureBlob) Mv(from string, to string) error {
 				return ErrNotValid
 			}
 			oldName := *blob.Name
-			newName := strings.Replace(oldName, apFrom.blobName, apTo.blobName, 1)
+			newName := strings.Replace(oldName, fromPrefix, toPrefix, 1)
 			sourceClient := this.client.ServiceClient().NewContainerClient(apFrom.containerName).NewBlockBlobClient(oldName)
 			destClient := this.client.ServiceClient().NewContainerClient(apTo.containerName).NewBlockBlobClient(newName)
 			if _, err := destClient.StartCopyFromURL(

--- a/server/plugin/plg_backend_s3/index.go
+++ b/server/plugin/plg_backend_s3/index.go
@@ -209,6 +209,9 @@ func (this S3Backend) Ls(path string) (files []os.FileInfo, err error) {
 		}
 		return files, nil
 	}
+	if p.path != "" {
+		p.path = EnforceDirectory(p.path)
+	}
 	client := s3.New(this.createSession(p.bucket))
 	start := time.Now()
 	err = client.ListObjectsV2PagesWithContext(
@@ -398,11 +401,15 @@ func (this S3Backend) Rm(path string) error {
 			wg.Done()
 		}()
 	}
+	prefix := p.path
+	if prefix != "" {
+		prefix = EnforceDirectory(prefix)
+	}
 	err = client.ListObjectsV2PagesWithContext(
 		ctx,
 		&s3.ListObjectsV2Input{
 			Bucket: aws.String(p.bucket),
-			Prefix: aws.String(p.path),
+			Prefix: aws.String(prefix),
 		},
 		func(objs *s3.ListObjectsV2Output, lastPage bool) bool {
 			if ctx.Err() != nil {
@@ -514,11 +521,19 @@ func (this S3Backend) Mv(from string, to string) error {
 			wg.Done()
 		}()
 	}
+	fromPrefix := f.path
+	if fromPrefix != "" {
+		fromPrefix = EnforceDirectory(fromPrefix)
+	}
+	toPrefix := t.path
+	if toPrefix != "" {
+		toPrefix = EnforceDirectory(toPrefix)
+	}
 	err = client.ListObjectsV2PagesWithContext(
 		ctx,
 		&s3.ListObjectsV2Input{
 			Bucket: aws.String(f.bucket),
-			Prefix: aws.String(f.path),
+			Prefix: aws.String(fromPrefix),
 		},
 		func(objs *s3.ListObjectsV2Output, lastPage bool) bool {
 			if ctx.Err() != nil {
@@ -527,7 +542,7 @@ func (this S3Backend) Mv(from string, to string) error {
 			for _, object := range objs.Contents {
 				jobChan <- []S3Path{
 					{f.bucket, *object.Key},
-					{t.bucket, t.path + strings.TrimPrefix(*object.Key, f.path)},
+					{t.bucket, toPrefix + strings.TrimPrefix(*object.Key, fromPrefix)},
 				}
 			}
 			return aws.BoolValue(objs.IsTruncated)


### PR DESCRIPTION
Backend fix for #994.

Folder list, delete and move on s3 and azure listed objects by the path as a prefix with no trailing slash, so a prefix of `folder` also matched the sibling `folderfoo`. On delete that wiped the sibling, on move it dragged it along and renamed it, and on list the folder showed itself and the sibling as children.

This adds the trailing slash to the listing prefix in `Ls`, `Rm` and `Mv` on both backends, and to the destination prefix on move so the rewritten keys line up. An empty prefix is left alone, so listing or deleting a whole bucket or container still works.

It is the backend side of #994. The WebDAV fix in #992 already stops this over WebDAV by adding the slash before the backend is called, but this makes the backend correct on its own so it cannot happen from any caller.

## Tested on an s3 share

- [X] Delete a folder without the trailing slash, a neighbouring folder sharing the name prefix is left intact
- [X] Move a folder without the trailing slash, the neighbouring folder is left intact