### PR TITLE
Fix: WOPI preview failure for Chinese filenames due to incorrect Base64 decoding

### DIFF
--- a/server/plugin/plg_editor_wopi/handler.go
+++ b/server/plugin/plg_editor_wopi/handler.go
@@ -107,7 +107,7 @@ func wopiToCommonAPI(fn HandlerFunc) HandlerFunc {
 		if len(tmp) < 2 {
 			return "", ""
 		}
-		bpath, err := base64.StdEncoding.DecodeString(tmp[1])
+		bpath, err := base64.URLEncoding.DecodeString(tmp[1])
 		if err != nil {
 			return "", ""
 		} else if len(tmp) > 2 {
@@ -278,7 +278,7 @@ func wopiDiscovery(ctx *App, fullpath string) (string, error) {
 		"id":   GenerateID(ctx.Session),
 		"path": fullpath,
 	})
-	wopiSRC += "::" + base64.StdEncoding.EncodeToString([]byte(fullpath))
+	wopiSRC += "::" + base64.URLEncoding.EncodeToString([]byte(fullpath))
 	if ctx.Share.Id != "" {
 		wopiSRC += "::" + ctx.Share.Id
 	}


### PR DESCRIPTION
 ### What's the problem?
  I encounter issues when trying to preview .doc files that start with Chinese characters (or certain multi-byte characters) via the WOPI integration. Users may observe error message "Unauthorized WOPI Host" in the web page.
Reported #850 

 ### Why does this happen?
  The plg_editor_wopi plugin uses base64.StdEncoding to decode the path64 parameter from the URL. However, when the browser/frontend generates these base64-encoded paths for use in URLs, it employs a URL-safe format (replacing + with - and / with _).

  When filenames start with specific multi-byte Chinese characters, the resulting base64 string is more likely to contain these URL-safe characters. base64.StdEncoding fails to handle these non-standard characters, leading to a corrupted path string.


###  How does this fix it?
  I have replaced base64.StdEncoding with base64.URLEncoding in server/plugin/plg_editor_wopi/handler.go.

   1. Decoding: Updated extractInfo to use base64.URLEncoding.DecodeString to correctly parse URL-safe base64 parameters.
   2. Encoding: Updated the logic where wopiSRC is constructed to use base64.URLEncoding.EncodeToString, ensuring consistency and robustness across the WOPI integration lifecycle.

  This change ensures symmetric and robust handling of file paths, effectively resolving the issue for filenames with non-ASCII characters without introducing compatibility risks.

###  Testing performed:
   - Reproduced the issue by uploading a file starting with Chinese characters (e.g., 中文测试.doc).
   - Verified that preview fails with the original code.
   - Applied the fix and confirmed that the preview now loads correctly.
   - Confirmed that English-starting filenames and standard file paths continue to work as expected.

fixed: #850 