### PR TITLE
feat: add config to disable manual login

### DIFF
--- a/server/common/config.go
+++ b/server/common/config.go
@@ -109,6 +109,7 @@ func NewConfiguration() Configuration {
 							FormElement{Name: "iframe", Type: "text", Default: "", Description: "list of domains who can use the application from an iframe. eg: https://example.com"},
 							FormElement{Name: "enable_chromecast", Type: "boolean", Default: true, Description: "Enable users to stream content on a chromecast device. This feature requires the browser to access google's server to download the chromecast SDK."},
 							FormElement{Name: "signature", Type: "text", Default: "", Description: "Enforce signature when using URL parameters in the authentication process"},
+							FormElement{Name: "disable_manual_login", Type: "boolean", Default: false, Description: "Disable manual login via POST /api/session. Enable when authentication should only occur through the configured identity provider (SSO)."},
 						},
 					},
 				},

--- a/server/ctrl/session.go
+++ b/server/ctrl/session.go
@@ -52,6 +52,11 @@ func SessionGet(ctx *App, res http.ResponseWriter, req *http.Request) {
 }
 
 func SessionAuthenticate(ctx *App, res http.ResponseWriter, req *http.Request) {
+	if Config.Get("features.protection.disable_manual_login").Bool() {
+		Log.Stdout("AUDIT action[blocked] backend[%v] target[%s] reason=manual_login_disabled", ctx.Body["type"], ip(req))
+		SendErrorResult(res, ErrNotAllowed)
+		return
+	}
 	ctx.Body["timestamp"] = time.Now().Format(time.RFC3339)
 	session := model.MapStringInterfaceToMapStringString(ctx.Body)
 	session["path"] = EnforceDirectory(session["path"])


### PR DESCRIPTION
When using SSO functionalities, we would want to be able to disable the manual authentication endpoint.